### PR TITLE
Create terraform-registry-manifest.json

### DIFF
--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+    "version": 1,
+    "metadata": {
+      "protocol_versions": ["6.0"]
+    }
+  }


### PR DESCRIPTION
This file is needed for publishing to Terraform Registry. 

`6.0` in the protocol_versions means that we are using Terraform Plugin Framework.