### PR TITLE
Refactor import code to one function

### DIFF
--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -222,7 +222,6 @@ func (r resourceApp) Update(ctx context.Context, req tfsdk_resource.UpdateReques
 		return
 	}
 
-	// Get current state
 	var state AblyApp
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -231,11 +230,13 @@ func (r resourceApp) Update(ctx context.Context, req tfsdk_resource.UpdateReques
 	}
 
 	// Gets the app ID
-	app_id := state.ID.Value
+	app_id := plan.ID.Value
+	if plan.ID.Unknown {
+		app_id = state.ID.Value
+	}
 
 	// Instantiates struct of type ably_control_go.App and sets values to output of plan
 	app_values := ably_control_go.App{
-		ID:                     plan.ID.Value,
 		AccountID:              plan.AccountID.Value,
 		Name:                   plan.Name.Value,
 		Status:                 plan.Status.Value,

--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -2,12 +2,9 @@ package ably_control
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	ably_control_go "github.com/ably/ably-control-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	tfsdk_provider "github.com/hashicorp/terraform-plugin-framework/provider"
 	tfsdk_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -201,7 +198,6 @@ func (r resourceKey) Update(ctx context.Context, req tfsdk_resource.UpdateReques
 		return
 	}
 
-	// Get current state
 	var state AblyKey
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -210,7 +206,7 @@ func (r resourceKey) Update(ctx context.Context, req tfsdk_resource.UpdateReques
 	}
 
 	// Gets the app ID and Key ID
-	app_id := state.AppID.Value
+	app_id := plan.AppID.Value
 	key_id := state.ID.Value
 
 	// Instantiates struct of type ably_control_go.NewKey and sets values to output of plan
@@ -277,18 +273,5 @@ func (r resourceKey) Delete(ctx context.Context, req tfsdk_resource.DeleteReques
 
 // // Import resource
 func (r resourceKey) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	// Save the import identifier in the id attribute
-	// identifier should be in the format app_id,key_id
-	idParts := strings.Split(req.ID, ",")
-
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: 'app_id,key_id'. Got: %q", req.ID),
-		)
-		return
-	}
-	// Recent PR in TF Plugin Framework for paths but Hashicorp examples not updated - https://github.com/hashicorp/terraform-plugin-framework/pull/390
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("app_id"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), idParts[1])...)
+	ImportResource(ctx, req, resp, "app_is", "id", "key")
 }

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -2,12 +2,9 @@ package ably_control
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	ably_control_go "github.com/ably/ably-control-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	tfsdk_provider "github.com/hashicorp/terraform-plugin-framework/provider"
 	tfsdk_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -226,17 +223,9 @@ func (r resourceNamespace) Update(ctx context.Context, req tfsdk_resource.Update
 		return
 	}
 
-	// Get current state
-	var state AblyNamespace
-	diags = req.State.Get(ctx, &state)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	// Gets the app ID and ID
-	app_id := state.AppID.Value
-	namespace_id := state.ID.Value
+	app_id := plan.AppID.Value
+	namespace_id := plan.ID.Value
 
 	// Instantiates struct of type ably_control_go.Namespace and sets values to output of plan
 	namespace_values := ably_control_go.Namespace{
@@ -307,16 +296,6 @@ func (r resourceNamespace) Delete(ctx context.Context, req tfsdk_resource.Delete
 
 // Import resource
 func (r resourceNamespace) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	idParts := strings.Split(req.ID, ",")
+	ImportResource(ctx, req, resp, "app_id", "id")
 
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: app_id,namespace_id. Got: %q", req.ID),
-		)
-		return
-	}
-
-	tfsdk_resource.ImportStatePassthroughID(ctx, path.Root("app_id"), tfsdk_resource.ImportStateRequest{ID: idParts[0]}, resp)
-	tfsdk_resource.ImportStatePassthroughID(ctx, path.Root("id"), tfsdk_resource.ImportStateRequest{ID: idParts[1]}, resp)
 }

--- a/internal/provider/resource_ably_queue.go
+++ b/internal/provider/resource_ably_queue.go
@@ -3,11 +3,11 @@ package ably_control
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	ably_control_go "github.com/ably/ably-control-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
+
 	tfsdk_provider "github.com/hashicorp/terraform-plugin-framework/provider"
 	tfsdk_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -32,6 +32,9 @@ func (r resourceQueueType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diag
 				Type:        types.StringType,
 				Computed:    true,
 				Description: "The ID of the queue",
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					tfsdk_resource.UseStateForUnknown(),
+				},
 			},
 			"name": {
 				Type:        types.StringType,
@@ -326,18 +329,7 @@ func (r resourceQueue) Delete(ctx context.Context, req tfsdk_resource.DeleteRequ
 
 // Import resource
 func (r resourceQueue) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	idParts := strings.Split(req.ID, ",")
-
-	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: app_id,queue_id. Got: %q", req.ID),
-		)
-		return
-	}
-
-	tfsdk_resource.ImportStatePassthroughID(ctx, path.Root("app_id"), tfsdk_resource.ImportStateRequest{ID: idParts[0]}, resp)
-	tfsdk_resource.ImportStatePassthroughID(ctx, path.Root("id"), tfsdk_resource.ImportStateRequest{ID: idParts[1]}, resp)
+	ImportResource(ctx, req, resp, "id")
 }
 
 var _ tfsdk_resource.ResourceWithModifyPlan = resourceQueue{}

--- a/internal/provider/resource_ably_rule_amqp.go
+++ b/internal/provider/resource_ably_rule_amqp.go
@@ -69,5 +69,5 @@ func (r resourceRuleAmqp) Delete(ctx context.Context, req tfsdk_resource.DeleteR
 
 // Import resource
 func (r resourceRuleAmqp) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_amqp_external.go
+++ b/internal/provider/resource_ably_rule_amqp_external.go
@@ -91,5 +91,6 @@ func (r resourceRuleAmqpExternal) Delete(ctx context.Context, req tfsdk_resource
 
 // Import resource
 func (r resourceRuleAmqpExternal) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
+
 }

--- a/internal/provider/resource_ably_rule_azure_function.go
+++ b/internal/provider/resource_ably_rule_azure_function.go
@@ -79,5 +79,5 @@ func (r resourceRuleAzureFunction) Delete(ctx context.Context, req tfsdk_resourc
 
 // Import resource
 func (r resourceRuleAzureFunction) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_http.go
+++ b/internal/provider/resource_ably_rule_http.go
@@ -74,5 +74,5 @@ func (r resourceRuleHTTP) Delete(ctx context.Context, req tfsdk_resource.DeleteR
 
 // Import resource
 func (r resourceRuleHTTP) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_http_cloudflare_worker.go
+++ b/internal/provider/resource_ably_rule_http_cloudflare_worker.go
@@ -72,5 +72,5 @@ func (r resourceRuleCloudflareWorker) Delete(ctx context.Context, req tfsdk_reso
 
 // Import resource
 func (r resourceRuleCloudflareWorker) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_http_google_cloud_function.go
+++ b/internal/provider/resource_ably_rule_http_google_cloud_function.go
@@ -85,5 +85,5 @@ func (r resourceRuleGoogleFunction) Delete(ctx context.Context, req tfsdk_resour
 
 // Import resource
 func (r resourceRuleGoogleFunction) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_ifttt.go
+++ b/internal/provider/resource_ably_rule_ifttt.go
@@ -72,5 +72,5 @@ func (r resourceRuleIFTTT) Delete(ctx context.Context, req tfsdk_resource.Delete
 
 // Import resource
 func (r resourceRuleIFTTT) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_kafka.go
+++ b/internal/provider/resource_ably_rule_kafka.go
@@ -105,5 +105,5 @@ func (r resourceRuleKafka) Delete(ctx context.Context, req tfsdk_resource.Delete
 
 // Import resource
 func (r resourceRuleKafka) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_kinesis.go
+++ b/internal/provider/resource_ably_rule_kinesis.go
@@ -77,5 +77,5 @@ func (r resourceRuleKinesis) Delete(ctx context.Context, req tfsdk_resource.Dele
 
 // Import resource
 func (r resourceRuleKinesis) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_lambda.go
+++ b/internal/provider/resource_ably_rule_lambda.go
@@ -72,5 +72,5 @@ func (r resourceRuleLambda) Delete(ctx context.Context, req tfsdk_resource.Delet
 
 // Import resource
 func (r resourceRuleLambda) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_pulsar.go
+++ b/internal/provider/resource_ably_rule_pulsar.go
@@ -103,5 +103,5 @@ func (r resourceRulePulsar) Delete(ctx context.Context, req tfsdk_resource.Delet
 
 // Import resource
 func (r resourceRulePulsar) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_sqs.go
+++ b/internal/provider/resource_ably_rule_sqs.go
@@ -80,5 +80,5 @@ func (r resourceRuleSqs) Delete(ctx context.Context, req tfsdk_resource.DeleteRe
 
 // Import resource
 func (r resourceRuleSqs) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_rule_zapier.go
+++ b/internal/provider/resource_ably_rule_zapier.go
@@ -73,5 +73,5 @@ func (r resourceRuleZapier) Delete(ctx context.Context, req tfsdk_resource.Delet
 
 // Import resource
 func (r resourceRuleZapier) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportRule(&r, ctx, req, resp)
+	ImportResource(ctx, req, resp, "app_id", "id")
 }


### PR DESCRIPTION
There's more I'd like to do here. Some other resources have private fields that we need to also allow importing. I'd also ideally like to remove the need to specify app_id during import. In theory you don't need it at it's specified in the template. But during the read function you can't get the plan only the state.

For now this fixes #125 and tidies up the code a bit.