### PR TITLE
Read key from control API

### DIFF
--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -173,7 +173,7 @@ func (r resourceKey) Read(ctx context.Context, req tfsdk_resource.ReadRequest, r
 				Name:       types.String{Value: v.Name},
 				Capability: v.Capability,
 				Status:     types.Int64{Value: int64(v.Status)},
-				Key:        state.Key,
+				Key:        types.String{Value: v.Key},
 				Created:    types.Int64{Value: int64(v.Created)},
 				Modified:   types.Int64{Value: int64(v.Modified)},
 			}
@@ -231,7 +231,7 @@ func (r resourceKey) Update(ctx context.Context, req tfsdk_resource.UpdateReques
 		Name:       types.String{Value: ably_key.Name},
 		Capability: ably_key.Capability,
 		Status:     types.Int64{Value: int64(ably_key.Status)},
-		Key:        state.Key,
+		Key:        types.String{Value: ably_key.Key},
 		Created:    types.Int64{Value: int64(ably_key.Created)},
 		Modified:   types.Int64{Value: int64(ably_key.Modified)},
 	}
@@ -273,5 +273,5 @@ func (r resourceKey) Delete(ctx context.Context, req tfsdk_resource.DeleteReques
 
 // // Import resource
 func (r resourceKey) ImportState(ctx context.Context, req tfsdk_resource.ImportStateRequest, resp *tfsdk_resource.ImportStateResponse) {
-	ImportResource(ctx, req, resp, "app_is", "id", "key")
+	ImportResource(ctx, req, resp, "app_id", "id")
 }

--- a/internal/provider/resource_ably_key_test.go
+++ b/internal/provider/resource_ably_key_test.go
@@ -27,6 +27,12 @@ func TestAccAblyKey(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_api_key.key0", "name", key_name),
 					resource.TestCheckResourceAttr("ably_api_key.key0", "capabilities.channel100.0", "publish"),
 					resource.TestCheckResourceAttr("ably_api_key.key0", "capabilities.channel100.1", "subscribe"),
+					resource.TestCheckResourceAttrWith("ably_api_key.key0", "key", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("key can't be empty")
+						}
+						return nil
+					}),
 				),
 			},
 			// Update and Read testing of ably_app.app0
@@ -36,6 +42,12 @@ func TestAccAblyKey(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_app.app0", "name", update_app_name),
 					resource.TestCheckResourceAttr("ably_api_key.key0", "name", update_key_name),
 					resource.TestCheckResourceAttr("ably_api_key.key0", "capabilities.channel100.0", "history"),
+					resource.TestCheckResourceAttrWith("ably_api_key.key0", "key", func(value string) error {
+						if value == "" {
+							return fmt.Errorf("key can't be empty")
+						}
+						return nil
+					}),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
The control API seems to now give the actual key data so we can read this instead of state. Other resources still do not expose secrets though, so we still need to read from state there.