### PR TITLE
Fix read and delete functions

### DIFF
--- a/internal/provider/error.go
+++ b/internal/provider/error.go
@@ -1,0 +1,10 @@
+package ably_control
+
+import (
+	ably_control_go "github.com/ably/ably-control-go"
+)
+
+func is_404(err error) bool {
+	e, ok := err.(ably_control_go.ErrorInfo)
+	return ok && e.StatusCode == 404
+}


### PR DESCRIPTION
When a resource was deleted, the read function would report no change instead of setting the state to null.

The delete function would throw an error if the resource had already been deleted, instead of just continuing.