### PR TITLE
Use set instead of list for capabilities

### DIFF
--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -40,7 +40,7 @@ func (r resourceKeyType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagno
 			},
 			"capabilities": {
 				Type: types.MapType{
-					ElemType: types.ListType{
+					ElemType: types.SetType{
 						ElemType: types.StringType,
 					},
 				},


### PR DESCRIPTION
The capabilities list seems to be unordered and will actually be returned in a different order than orifinally specified. Make this a set so terraform does not complain about the order mismatch.