### PR TITLE
Append 'terraform-provider-ably/VERSION' to the Ably-Agent HTTP header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,18 @@ build:
 	go build -o ${BINARY}
 
 release:
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
-	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
-	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
-	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
-	GOOS=linux GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_linux_386
-	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
-	GOOS=linux GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_linux_arm
-	GOOS=openbsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_openbsd_386
-	GOOS=openbsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
-	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
-	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
-	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
+	GOOS=darwin  GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=freebsd GOARCH=386   go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_freebsd_386
+	GOOS=freebsd GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
+	GOOS=freebsd GOARCH=arm   go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_freebsd_arm
+	GOOS=linux   GOARCH=386   go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_linux_386
+	GOOS=linux   GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_linux_amd64
+	GOOS=linux   GOARCH=arm   go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_linux_arm
+	GOOS=openbsd GOARCH=386   go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_openbsd_386
+	GOOS=openbsd GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
+	GOOS=solaris GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_solaris_amd64
+	GOOS=windows GOARCH=386   go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_windows_386
+	GOOS=windows GOARCH=amd64 go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
 install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ably/terraform-provider-ably
 go 1.19
 
 require (
-	github.com/ably/ably-control-go v0.0.0-20221128140941-7c2438594cd5
+	github.com/ably/ably-control-go v0.1.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.21.0

--- a/go.sum
+++ b/go.sum
@@ -12,10 +12,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/ably/ably-control-go v0.0.0-20221122111739-22a996972f04 h1:Ahdo3Qx+0Fews3F7bO6gkunCnDi0KXqUYCv33rI9H78=
-github.com/ably/ably-control-go v0.0.0-20221122111739-22a996972f04/go.mod h1:TP7gWAy+ga++gX6OZ0DtjwH8oVKKdiaIGQvZvxDKNdk=
-github.com/ably/ably-control-go v0.0.0-20221128140941-7c2438594cd5 h1:xBt4mG1ikDv1pX228HvTLDEvPYjzzoIHZcC5wsdKSms=
-github.com/ably/ably-control-go v0.0.0-20221128140941-7c2438594cd5/go.mod h1:TP7gWAy+ga++gX6OZ0DtjwH8oVKKdiaIGQvZvxDKNdk=
+github.com/ably/ably-control-go v0.1.0 h1:flhd5ZiJZyWs+RxOK//ozsev6VpmRrqOmvXhVvgon3I=
+github.com/ably/ably-control-go v0.1.0/go.mod h1:TP7gWAy+ga++gX6OZ0DtjwH8oVKKdiaIGQvZvxDKNdk=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,13 +15,16 @@ import (
 
 const CONTROL_API_DEFAULT_URL = "https://control.ably.net/v1"
 
-func New() tfsdk_provider.Provider {
-	return &provider{}
+func New(version string) tfsdk_provider.Provider {
+	return &provider{
+		version: version,
+	}
 }
 
 type provider struct {
 	configured bool
 	client     *ably_control_go.Client
+	version    string
 }
 
 // GetSchema
@@ -113,6 +116,7 @@ func (p *provider) Configure(ctx context.Context, req tfsdk_provider.ConfigureRe
 		)
 		return
 	}
+	c.AppendAblyAgent("terraform-provider-ably", p.version)
 
 	p.client = &c
 	p.configured = true

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	ably_control "github.com/ably/terraform-provider-ably/internal/provider"
 
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
@@ -15,6 +16,9 @@ import (
 //
 // It defaults to "dev" but is overridden during the release process using
 // ldflags (e.g. go build -ldflags="-X main.VERSION=x.y.z").
+//
+// It is appended to the Ably-Agent HTTP header sent by the underlying Control
+// API client (e.g. 'Ably-Agent: ably-control-go/1.0 terraform-provider-ably/x.y.z').
 var VERSION = "dev"
 
 func main() {
@@ -28,9 +32,13 @@ func main() {
 		Address: "registry.terraform.io/ably/terraform-provider-ably",
 	}
 
-	err := providerserver.Serve(context.Background(), ably_control.New, opts)
+	err := providerserver.Serve(context.Background(), newProvider, opts)
 
 	if err != nil {
 		log.Fatal(err.Error())
 	}
+}
+
+func newProvider() provider.Provider {
+	return ably_control.New(VERSION)
 }

--- a/main.go
+++ b/main.go
@@ -2,14 +2,27 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
 
 	ably_control "github.com/ably/terraform-provider-ably/internal/provider"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
+// VERSION is the version of this provider.
+//
+// It defaults to "dev" but is overridden during the release process using
+// ldflags (e.g. go build -ldflags="-X main.VERSION=x.y.z").
+var VERSION = "dev"
+
 func main() {
+	// print the version and exit if argv[1] is "version"
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		fmt.Println("terraform-provider-ably " + VERSION)
+		os.Exit(0)
+	}
 
 	opts := providerserver.ServeOpts{
 		Address: "registry.terraform.io/ably/terraform-provider-ably",


### PR DESCRIPTION
To improve how we track the usage of this Terraform provider.