### PR TITLE
Release/0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change log
 
+## [0.4.3](https://github.com/ably/terraform-provider-ably/tree/v0.4.3)
+
+[Full Changelog](https://github.com/ably/terraform-provider-ably/compare/v0.4.2...v0.4.3)
+
+**Merged pull requests:**
+
+- Append 'terraform-provider-ably/VERSION' to the Ably-Agent HTTP header [\#156](https://github.com/ably/terraform-provider-ably/pull/156) ([lmars](https://github.com/lmars))
+- add credit to CHANGELOG for external contribution [\#155](https://github.com/ably/terraform-provider-ably/pull/155) ([owenpearson](https://github.com/owenpearson))
+
 ## [0.4.2](https://github.com/ably/terraform-provider-ably/tree/v0.4.2)
 
 Bugfixes:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=ably
 NAME=ably
 BINARY=terraform-provider-${NAME}
-VERSION=0.4.2
+VERSION=0.4.3
 OS_ARCH=darwin_amd64
 
 default: install


### PR DESCRIPTION
So that the latest version of the provider [sets the `Ably-Agent` header](https://github.com/ably/terraform-provider-ably/pull/156).