### PR TITLE
[INF-3250] - Update Contributing and Provider documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,12 @@
 ## Contributing
 
 1. Fork it
-3. Create your feature branch (`git checkout -b my-new-feature`)
-4. Commit your changes (`git commit -am 'Add some feature'`)
-5. Ensure you have added suitable tests and the test suite is passing
-8. Push the branch (`git push origin my-new-feature`)
-9. Create a new Pull Request
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Ensure you have added suitable tests and the test suite is passing
+5. Ensure that `tfplugindocs` has been run and that the Ably Terraform provider documentation is up to date. Terraform Plugin Docs tool is available [HERE](https://github.com/hashicorp/terraform-plugin-docs)
+6. Push the branch (`git push origin my-new-feature`)
+7. Create a new Pull Request
 
 ## Release Process
 

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -33,6 +33,10 @@ resource "ably_api_key" "api_key_1" {
 - `capabilities` (Map of Set of String) The capabilities that this key has. More information on capabilities can be found in the [Ably documentation](https://ably.com/docs/core-features/authentication#capabilities-explained)
 - `name` (String) The name for your API key. This is a friendly name for your reference.
 
+### Optional
+
+- `revocable_tokens` (Boolean) Allow tokens issued by this key to be revoked. More information on Token Revocation can be found in the [Ably documentation](https://ably.com/docs/auth/revocation)
+
 ### Read-Only
 
 - `created` (Number) Enforce TLS for all connections. This setting overrides any channel setting.


### PR DESCRIPTION
- Updates the CONTRIBUTING.md file with information on tfplugindocs (https://github.com/hashicorp/terraform-plugin-docs) to generate provider documentation.
- Also update CONTRIBUTING.md to fix ordered list of instructions for Contributing.
- Update the Ably Terraform provider documentation for API Keys.