### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.1](https://github.com/ably/terraform-provider-ably/tree/v0.6.1)
+
+[Full Changelog](https://github.com/ably/terraform-provider-ably/compare/v0.6.0...v0.6.1)
+
+**Merged pull requests:**
+
+- \[INF-3250\] - Update Contributing and Provider documentation [\#176](https://github.com/ably/terraform-provider-ably/pull/176) ([graham-russell](https://github.com/graham-russell))
+
 ## [0.6.0](https://github.com/ably/terraform-provider-ably/tree/v0.6.0)
 
 [Full Changelog](https://github.com/ably/terraform-provider-ably/compare/v0.5.0...v0.6.0)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ terraform {
   required_providers {
     ably = {
       source  = "ably/ably"
-      version = "0.6.0"
+      version = "0.6.1"
     }
   }
 }


### PR DESCRIPTION
Update contribution and Ably Terraform Provider documentation. Also update version numbers in README.md.
This is being done in preparation for the release of version 0.6.1 of the Ably Terraform Provider.