### PR TITLE
Use types.Set rather than []types.String

### DIFF
--- a/examples/playground/key.tf
+++ b/examples/playground/key.tf
@@ -14,8 +14,8 @@ resource "ably_api_key" "api_key_1" {
   name             = "key-0001"
   revocable_tokens = false
   capabilities = {
-    "channel1" = ["subscribe"],
-    "channel2" = ["publish"],
-    "channel3" = ["subscribe"],
+    "channel1" = ["subscribe", "publish", "presence"],
+    "channel2" = ["publish", "presence", "subscribe"],
+    "channel3" = ["presence", "subscribe", "publish"],
   }
 }

--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -42,7 +42,7 @@ func (r *ResourceKey) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Description: "The name for your API key. This is a friendly name for your reference.",
 			},
 			"capabilities": schema.MapAttribute{
-				ElementType: types.ListType{
+				ElementType: types.SetType{
 					ElemType: types.StringType,
 				},
 				Required:    true,
@@ -110,7 +110,7 @@ func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Convert capability map from Terraform types to Go strings
-	capability := mapFromStringSlice(plan.Capability)
+	capability := mapFromSet(ctx, plan.Capability)
 
 	newKey := control.NewKey{
 		Name:            plan.Name.ValueString(),
@@ -130,7 +130,7 @@ func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, res
 
 	// Maps response body to resource schema attributes.
 	// Convert capability map from Go strings to Terraform types
-	tfCapability := mapToTypedStringSlice(ablyKey.Capability)
+	tfCapability := mapToTypedSet(ablyKey.Capability)
 
 	respKey := AblyKey{
 		ID:              types.StringValue(ablyKey.ID),
@@ -187,7 +187,7 @@ func (r ResourceKey) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	for _, v := range keys {
 		if v.AppID == appID && v.ID == keyID && v.Status == 0 {
 			// Convert capability map from Go strings to Terraform types
-			tfCapability := mapToTypedStringSlice(v.Capability)
+			tfCapability := mapToTypedSet(v.Capability)
 
 			respKey := AblyKey{
 				ID:              types.StringValue(v.ID),
@@ -242,7 +242,7 @@ func (r ResourceKey) Update(ctx context.Context, req resource.UpdateRequest, res
 	// Instantiates struct of type control.NewKey and sets values to output of plan
 	keyValues := control.NewKey{
 		Name:            plan.Name.ValueString(),
-		Capability:      mapFromStringSlice(plan.Capability),
+		Capability:      mapFromSet(ctx, plan.Capability),
 		RevocableTokens: plan.RevocableTokens.ValueBool(),
 	}
 
@@ -257,7 +257,7 @@ func (r ResourceKey) Update(ctx context.Context, req resource.UpdateRequest, res
 	}
 
 	// Convert capability map from Go strings to Terraform types
-	tfCapability := mapToTypedStringSlice(ablyKey.Capability)
+	tfCapability := mapToTypedSet(ablyKey.Capability)
 
 	respKey := AblyKey{
 		ID:              types.StringValue(ablyKey.ID),

--- a/internal/provider/resource_ably_key_test.go
+++ b/internal/provider/resource_ably_key_test.go
@@ -70,10 +70,10 @@ terraform {
 		}
 	}
 }
-	
+
 # You can provide your Ably Token & URL inline or use environment variables ABLY_ACCOUNT_TOKEN & ABLY_URL
 provider "ably" {}
-	  
+
 resource "ably_app" "app0" {
 	name     = %[1]q
 	status   = "enabled"


### PR DESCRIPTION
We had an issue where the ordering was not guaranteed by the API and so it produced inconsistent results when applying:

```
| Error: Provider produced inconsistent result after apply
│
│ When applying changes to ably_api_key.this, provider
│ "provider[\"registry.opentofu.org/ably/ably\"]" produced an
│ unexpected new value: .capabilities["foo"][0]: was
│ cty.StringVal("publish"), but now cty.StringVal("presence").
│
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
╵
```

Rather than use a slice of `types.String`, instead use `types.Set` that does not depend on order and guarantees unique values.
