### PR TITLE
Add retry logic for transient failures

### DIFF
--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -135,7 +135,12 @@ func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Creates a new Ably App by invoking the CreateApp function from the Client Library
-	ablyApp, err := r.p.client.CreateApp(&appValues)
+	var ablyApp control.App
+	err := retryWithBackoff(ctx, "CreateApp", func() error {
+		var createErr error
+		ablyApp, createErr = r.p.client.CreateApp(&appValues)
+		return createErr
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating Resource",
@@ -187,7 +192,12 @@ func (r ResourceApp) Read(ctx context.Context, req resource.ReadRequest, resp *r
 
 	// Fetches all Ably Apps in the account. The function invokes the Client Library Apps() method.
 	// NOTE: Control API & Client Lib do not currently support fetching single app given app id
-	apps, err := r.p.client.Apps()
+	var apps []control.App
+	err := retryWithBackoff(ctx, "Apps", func() error {
+		var readErr error
+		apps, readErr = r.p.client.Apps()
+		return readErr
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading Resource",
@@ -270,7 +280,12 @@ func (r ResourceApp) Update(ctx context.Context, req resource.UpdateRequest, res
 	}
 
 	// Updates an Ably App. The function invokes the Client Library UpdateApp method.
-	ablyApp, err := r.p.client.UpdateApp(appID, &appValues)
+	var ablyApp control.App
+	err := retryWithBackoff(ctx, "UpdateApp", func() error {
+		var updateErr error
+		ablyApp, updateErr = r.p.client.UpdateApp(appID, &appValues)
+		return updateErr
+	})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating Resource",
@@ -317,7 +332,9 @@ func (r ResourceApp) Delete(ctx context.Context, req resource.DeleteRequest, res
 	// Gets the current state. If it is unable to, the provider responds with an error.
 	appID := state.ID.ValueString()
 
-	err := r.p.client.DeleteApp(appID)
+	err := retryWithBackoff(ctx, "DeleteApp", func() error {
+		return r.p.client.DeleteApp(appID)
+	})
 	if err != nil {
 		if is404(err) {
 			resp.Diagnostics.AddWarning(

--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -201,7 +201,7 @@ func (r ResourceApp) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading Resource",
-			"Could not create resource, unexpected error: "+err.Error(),
+			"Could not read resource, unexpected error: "+err.Error(),
 		)
 		return
 	}

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -1,0 +1,121 @@
+// Package provider implements the Ably provider for Terraform
+package provider
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"net"
+	"net/url"
+	"time"
+
+	control "github.com/ably/ably-control-go"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	maxRetries     = 3
+	initialBackoff = 1 * time.Second
+	maxBackoff     = 30 * time.Second
+)
+
+// isRetryableError determines if an error is transient and should be retried
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for network errors
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// Check for URL errors (connection failures)
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+
+	// Check for Ably control API errors
+	var controlErr control.ErrorInfo
+	if errors.As(err, &controlErr) {
+		// Retry on:
+		// - Status code 0 (connection error)
+		// - Status code 429 (rate limit)
+		// - Status codes 5xx (server errors)
+		// Don't retry on 4xx client errors (except 429)
+		if controlErr.StatusCode == 0 || controlErr.StatusCode == 429 {
+			return true
+		}
+		if controlErr.StatusCode >= 500 && controlErr.StatusCode < 600 {
+			return true
+		}
+		return false
+	}
+
+	return false
+}
+
+// backoff returns the backoff duration for a given attempt (0-indexed)
+// Uses exponential backoff with equal jitter: 1s, 4s, 16s, ... capped at maxBackoff
+func backoff(attempt int) time.Duration {
+	b := initialBackoff << (attempt * 2) // equivalent to initialBackoff * 4^attempt
+	b = min(b, maxBackoff)
+	return b/2 + rand.N(b/2) // Equal jitter: 50-100% of calculated backoff
+}
+
+// retryWithBackoff retries a function with exponential backoff
+func retryWithBackoff(ctx context.Context, operation string, fn func() error) error {
+	var lastErr error
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			wait := backoff(attempt - 1)
+			tflog.Warn(ctx, "Retrying operation after error",
+				map[string]interface{}{
+					"operation": operation,
+					"attempt":   attempt,
+					"backoff":   wait.String(),
+					"error":     lastErr.Error(),
+				})
+
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		lastErr = fn()
+
+		if lastErr == nil {
+			if attempt > 0 {
+				tflog.Info(ctx, "Operation succeeded after retry",
+					map[string]interface{}{
+						"operation": operation,
+						"attempt":   attempt,
+					})
+			}
+			return nil
+		}
+
+		if !isRetryableError(lastErr) {
+			tflog.Debug(ctx, "Error is not retryable",
+				map[string]interface{}{
+					"operation": operation,
+					"error":     lastErr.Error(),
+				})
+			return lastErr
+		}
+	}
+
+	tflog.Error(ctx, "Operation failed after max retries",
+		map[string]interface{}{
+			"operation":   operation,
+			"max_retries": maxRetries,
+			"error":       lastErr.Error(),
+		})
+
+	return lastErr
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -1,0 +1,211 @@
+// Package provider implements the Ably provider for Terraform
+package provider
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"testing"
+	"time"
+
+	control "github.com/ably/ably-control-go"
+)
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "status code 0",
+			err:      control.ErrorInfo{StatusCode: 0},
+			expected: true,
+		},
+		{
+			name:     "status code 429 (rate limit)",
+			err:      control.ErrorInfo{StatusCode: 429},
+			expected: true,
+		},
+		{
+			name:     "status code 500 (server error)",
+			err:      control.ErrorInfo{StatusCode: 500},
+			expected: true,
+		},
+		{
+			name:     "status code 503 (service unavailable)",
+			err:      control.ErrorInfo{StatusCode: 503},
+			expected: true,
+		},
+		{
+			name:     "status code 404 (not found)",
+			err:      control.ErrorInfo{StatusCode: 404},
+			expected: false,
+		},
+		{
+			name:     "status code 400 (bad request)",
+			err:      control.ErrorInfo{StatusCode: 400},
+			expected: false,
+		},
+		{
+			name:     "url error",
+			err:      &url.Error{Op: "Get", URL: "http://example.com", Err: errors.New("connection refused")},
+			expected: true,
+		},
+		{
+			name:     "net timeout error",
+			err:      &netTimeoutError{},
+			expected: true,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("something went wrong"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableError(tt.err)
+			if result != tt.expected {
+				t.Errorf("isRetryableError(%v) = %v; want %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+// netTimeoutError is a test helper that implements net.Error
+type netTimeoutError struct{}
+
+func (e *netTimeoutError) Error() string   { return "timeout" }
+func (e *netTimeoutError) Timeout() bool   { return true }
+func (e *netTimeoutError) Temporary() bool { return true }
+
+var _ net.Error = (*netTimeoutError)(nil)
+
+func TestRetryWithBackoff(t *testing.T) {
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		ctx := context.Background()
+		callCount := 0
+
+		err := retryWithBackoff(ctx, "test", func() error {
+			callCount++
+			return nil
+		})
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if callCount != 1 {
+			t.Errorf("expected 1 call, got %d", callCount)
+		}
+	})
+
+	t.Run("retries on retryable error", func(t *testing.T) {
+		ctx := context.Background()
+		callCount := 0
+
+		err := retryWithBackoff(ctx, "test", func() error {
+			callCount++
+			if callCount < 3 {
+				return control.ErrorInfo{StatusCode: 0} // Connection error
+			}
+			return nil
+		})
+
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if callCount != 3 {
+			t.Errorf("expected 3 calls, got %d", callCount)
+		}
+	})
+
+	t.Run("does not retry on non-retryable error", func(t *testing.T) {
+		ctx := context.Background()
+		callCount := 0
+
+		err := retryWithBackoff(ctx, "test", func() error {
+			callCount++
+			return control.ErrorInfo{StatusCode: 404}
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if callCount != 1 {
+			t.Errorf("expected 1 call, got %d", callCount)
+		}
+	})
+
+	t.Run("respects max retries", func(t *testing.T) {
+		ctx := context.Background()
+		callCount := 0
+
+		err := retryWithBackoff(ctx, "test", func() error {
+			callCount++
+			return control.ErrorInfo{StatusCode: 503} // Service unavailable
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		// Should be called 4 times: initial attempt + 3 retries
+		if callCount != 4 {
+			t.Errorf("expected 4 calls (initial + 3 retries), got %d", callCount)
+		}
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		callCount := 0
+
+		err := retryWithBackoff(ctx, "test", func() error {
+			callCount++
+			return control.ErrorInfo{StatusCode: 500} // Server error
+		})
+
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		// Should be called at least once, but not the full 4 times due to context timeout
+		if callCount > 2 {
+			t.Errorf("expected at most 2 calls due to context timeout, got %d", callCount)
+		}
+	})
+}
+
+func TestBackoff(t *testing.T) {
+	// With equal jitter, backoff returns 50-100% of the base value
+	// Base values: 1s, 4s, 16s, 64s (capped at 30s)
+	tests := []struct {
+		attempt int
+		min     time.Duration
+		max     time.Duration
+	}{
+		{0, 500 * time.Millisecond, 1 * time.Second},   // base 1s
+		{1, 2 * time.Second, 4 * time.Second},          // base 4s
+		{2, 8 * time.Second, 16 * time.Second},         // base 16s
+		{3, 15 * time.Second, 30 * time.Second},        // base 64s, capped at 30s
+		{10, 15 * time.Second, 30 * time.Second},       // capped at 30s
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			// Run multiple times to account for randomness
+			for i := 0; i < 100; i++ {
+				result := backoff(tt.attempt)
+				if result < tt.min || result > tt.max {
+					t.Errorf("backoff(%d) = %v; want between %v and %v", tt.attempt, result, tt.min, tt.max)
+				}
+			}
+		})
+	}
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -4,6 +4,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/url"
 	"testing"
@@ -198,7 +199,7 @@ func TestBackoff(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(fmt.Sprintf("attempt_%d", tt.attempt), func(t *testing.T) {
 			// Run multiple times to account for randomness
 			for i := 0; i < 100; i++ {
 				result := backoff(tt.attempt)

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -198,11 +198,11 @@ func TestBackoff(t *testing.T) {
 		min     time.Duration
 		max     time.Duration
 	}{
-		{0, 500 * time.Millisecond, 1 * time.Second},   // base 1s
-		{1, 2 * time.Second, 4 * time.Second},          // base 4s
-		{2, 8 * time.Second, 16 * time.Second},         // base 16s
-		{3, 15 * time.Second, 30 * time.Second},        // base 64s, capped at 30s
-		{10, 15 * time.Second, 30 * time.Second},       // capped at 30s
+		{0, 500 * time.Millisecond, 1 * time.Second}, // base 1s
+		{1, 2 * time.Second, 4 * time.Second},        // base 4s
+		{2, 8 * time.Second, 16 * time.Second},       // base 16s
+		{3, 15 * time.Second, 30 * time.Second},      // base 64s, capped at 30s
+		{10, 15 * time.Second, 30 * time.Second},     // capped at 30s
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This commit adds in retry logic with backoff and jitter to all the CRUD operations of the provider.

closes https://github.com/ably/terraform-provider-ably/issues/217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automatic retry with exponential backoff for external API operations to improve reliability and resilience.
* **Bug Fixes**
  * Corrected error messaging for read operations to reflect the proper action.
* **Tests**
  * Added unit tests covering retry behavior, backoff timing, classification of transient errors, retry limits, and context cancellation handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->