### PR TITLE
[INF-6633] Bump API client to v0.8.0

### DIFF
--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -30,7 +30,7 @@ resource "ably_api_key" "api_key_1" {
 ### Required
 
 - `app_id` (String) The Ably application ID which this key is associated with.
-- `capabilities` (Map of List of String) The capabilities that this key has. More information on capabilities can be found in the [Ably documentation](https://ably.com/docs/core-features/authentication#capabilities-explained)
+- `capabilities` (Map of Set of String) The capabilities that this key has. More information on capabilities can be found in the [Ably documentation](https://ably.com/docs/core-features/authentication#capabilities-explained)
 - `name` (String) The name for your API key. This is a friendly name for your reference.
 
 ### Optional

--- a/docs/resources/rule_amqp_external.md
+++ b/docs/resources/rule_amqp_external.md
@@ -77,7 +77,6 @@ Optional:
 
 Required:
 
-- `exchange` (String) The RabbitMQ exchange, if needed, supports interpolation; see https://faqs.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule for more info. If you don't use RabbitMQ exchanges, leave this blank.
 - `mandatory_route` (Boolean) Reject delivery of the message if the route does not exist, otherwise fail silently.
 - `persistent_messages` (Boolean) Marks the message as persistent, instructing the broker to write it to disk if it is in a durable queue.
 - `routing_key` (String) The Kafka partition key. This is used to determine which partition a message should be routed to, where a topic has been partitioned. routingKey should be in the format topic:key where topic is the topic to publish to, and key is the value to use as the message key

--- a/examples/playground/rule_amqp_external.tf
+++ b/examples/playground/rule_amqp_external.tf
@@ -9,7 +9,6 @@ resource "ably_rule_amqp_external" "rule0" {
   target = {
     url                 = "amqps://test.com"
     routing_key         = "new:key"
-    exchange            = "testexchange"
     mandatory_route     = true
     persistent_messages = true
     message_ttl         = 55

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
-	github.com/ably/ably-control-go v0.6.0
+	github.com/ably/ably-control-go v0.8.0
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.17.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
@@ -37,7 +37,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,10 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/ably/ably-control-go v0.6.0 h1:ggHUNoRRaIo3p/ZDje9rUcfe6JoDoGFHXT8BJqbjrso=
-github.com/ably/ably-control-go v0.6.0/go.mod h1:MWf+x/h4ZlU5U0Nfgzte7lM5NtTYgI9sfBeOydXA/DA=
+github.com/ably/ably-control-go v0.7.0 h1:WajuwzZUbS27W4BmubGe3sFzCqJ+L3DB6kcQotjsZHU=
+github.com/ably/ably-control-go v0.7.0/go.mod h1:pv7BspbElyeHlG5+RcT1JTS+g2yKEQn48rfB8xQRcew=
+github.com/ably/ably-control-go v0.8.0 h1:seA4uvPPJKPmj7HeDK3xQ0AQCL1fh8VGGUrTigfkVsQ=
+github.com/ably/ably-control-go v0.8.0/go.mod h1:pv7BspbElyeHlG5+RcT1JTS+g2yKEQn48rfB8xQRcew=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -89,8 +91,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.7.0 h1:YghfQH/0QmPNc/AZMTFE3ac8fipZyZECHdDPshfk+mA=
 github.com/hashicorp/go-plugin v1.7.0/go.mod h1:BExt6KEaIYx804z8k4gRzRLEvxKVb+kn0NMcihqOqb8=
-github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
-github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
+github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -334,7 +334,6 @@ type AblyRuleTargetAMQP struct {
 type AblyRuleTargetAMQPExternal struct {
 	Url                types.String      `tfsdk:"url"`
 	RoutingKey         types.String      `tfsdk:"routing_key"`
-	Exchange           types.String      `tfsdk:"exchange"`
 	MandatoryRoute     types.Bool        `tfsdk:"mandatory_route"`
 	PersistentMessages types.Bool        `tfsdk:"persistent_messages"`
 	MessageTtl         types.Int64       `tfsdk:"message_ttl"`

--- a/internal/provider/resource_ably_ingress_rule_postgres_outbox_test.go
+++ b/internal/provider/resource_ably_ingress_rule_postgres_outbox_test.go
@@ -12,8 +12,8 @@ import (
 func TestAccAblyIngressRulePostgresOutbox(t *testing.T) {
 	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	updateAppName := "acc-test-" + appName
-	testPostgresURL := "postgres://test:test@test.com:5432/your-database-name"
-	testUpdatePostgresURL := "postgres://test:test@example.com:5432/your-database-name"
+	testPostgresURL := "postgres://test:test@example.com:5432/your-database-name"
+	testUpdatePostgresURL := "postgres://test:test@example.net:5432/your-database-name"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/resource_ably_rule_amqp_external.go
+++ b/internal/provider/resource_ably_rule_amqp_external.go
@@ -27,10 +27,6 @@ func (r ResourceRuleAMQPExternal) Schema(_ context.Context, _ resource.SchemaReq
 				Required:    true,
 				Description: "The Kafka partition key. This is used to determine which partition a message should be routed to, where a topic has been partitioned. routingKey should be in the format topic:key where topic is the topic to publish to, and key is the value to use as the message key",
 			},
-			"exchange": schema.StringAttribute{
-				Required:    true,
-				Description: "The RabbitMQ exchange, if needed, supports interpolation; see https://faqs.ably.com/what-is-the-format-of-the-routingkey-for-an-amqp-or-kinesis-reactor-rule for more info. If you don't use RabbitMQ exchanges, leave this blank.",
-			},
 			"mandatory_route": schema.BoolAttribute{
 				Required:    true,
 				Description: "Reject delivery of the message if the route does not exist, otherwise fail silently.",

--- a/internal/provider/resource_ably_rule_amqp_external_test.go
+++ b/internal/provider/resource_ably_rule_amqp_external_test.go
@@ -43,7 +43,6 @@ func TestAccAblyRuleAMQPExternal(t *testing.T) {
 					"channel.message",
 					"amqps://test.example",
 					"topic:key",
-					"exchange",
 					true,
 					true,
 					44,
@@ -57,7 +56,6 @@ func TestAccAblyRuleAMQPExternal(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "source.channel_filter", "^my-channel.*"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "source.type", "channel.message"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.routing_key", "topic:key"),
-					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.exchange", "exchange"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.enveloped", "true"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.format", "json"),
 				),
@@ -71,7 +69,6 @@ func TestAccAblyRuleAMQPExternal(t *testing.T) {
 					"channel.message",
 					"amqps://test.example",
 					"newtopic:key",
-					"newexchange",
 					false,
 					false,
 					23,
@@ -85,7 +82,6 @@ func TestAccAblyRuleAMQPExternal(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "source.channel_filter", "^my-channel.*"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "source.type", "channel.message"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.routing_key", "newtopic:key"),
-					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.exchange", "newexchange"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.enveloped", "false"),
 					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "target.format", "msgpack"),
 				),
@@ -103,7 +99,6 @@ func testAccAblyRuleAMQPExternalConfig(
 	sourceType string,
 	targetURL string,
 	targetRoutingKey string,
-	targetExchange string,
 	targetMandatoryRoute bool,
 	targetPersistentMessages bool,
 	targetMessageTTL int,
@@ -119,10 +114,10 @@ terraform {
 		}
 	}
 }
-	
+
 # You can provide your Ably Token & URL inline or use environment variables ABLY_ACCOUNT_TOKEN & ABLY_URL
 provider "ably" {}
-	  
+
 resource "ably_app" "app0" {
 	name     = %[1]q
 	status   = "enabled"
@@ -139,15 +134,14 @@ resource "ably_rule_amqp_external" "rule0" {
 	target = {
 	  url = %[5]q
 	  routing_key = %[6]q,
-	  exchange = %[7]q,
-	  mandatory_route = %[8]t
-	  persistent_messages = %[9]t
-	  message_ttl = %[10]d
-	  headers = %[11]s
-	  enveloped = %[12]s,
-	  format    = %[13]q,
-	  
+	  mandatory_route = %[7]t
+	  persistent_messages = %[8]t
+	  message_ttl = %[9]d
+	  headers = %[10]s
+	  enveloped = %[11]s,
+	  format    = %[12]q,
+
 	}
   }
-`, appName, ruleStatus, channelFilter, sourceType, targetURL, targetRoutingKey, targetExchange, targetMandatoryRoute, targetPersistentMessages, targetMessageTTL, targetHeaders, targetEnveloped, targetFormat)
+`, appName, ruleStatus, channelFilter, sourceType, targetURL, targetRoutingKey, targetMandatoryRoute, targetPersistentMessages, targetMessageTTL, targetHeaders, targetEnveloped, targetFormat)
 }

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -166,7 +166,6 @@ func GetPlanRule(plan AblyRule) control.NewRule {
 		target = &control.AmqpExternalTarget{
 			Url:                t.Url.ValueString(),
 			RoutingKey:         t.RoutingKey.ValueString(),
-			Exchange:           t.Exchange.ValueString(),
 			MandatoryRoute:     t.MandatoryRoute.ValueBool(),
 			PersistentMessages: t.PersistentMessages.ValueBool(),
 			MessageTTL:         int(t.MessageTtl.ValueInt64()),
@@ -295,11 +294,18 @@ func GetRuleResponse(ablyRule *control.Rule, plan *AblyRule) AblyRule {
 			Headers:      headers,
 		}
 	case *control.PulsarTarget:
+		// TlsTrustCerts is write-only in the API (accepted on create/update but
+		// never returned on read), so preserve whatever the user configured in
+		// state rather than overwriting it with nil from the API response.
+		var tlsTrustCerts []types.String
+		if p, ok := plan.Target.(*AblyRuleTargetPulsar); ok {
+			tlsTrustCerts = p.TlsTrustCerts
+		}
 		respTarget = &AblyRuleTargetPulsar{
 			RoutingKey:    types.StringValue(v.RoutingKey),
 			Topic:         types.StringValue(v.Topic),
 			ServiceURL:    types.StringValue(v.ServiceURL),
-			TlsTrustCerts: toTypedStringSlice(v.TlsTrustCerts),
+			TlsTrustCerts: tlsTrustCerts,
 			Authentication: PulsarAuthentication{
 				Mode:  types.StringValue(string(v.Authentication.AuthenticationMode)),
 				Token: types.StringValue(v.Authentication.Token),
@@ -377,7 +383,6 @@ func GetRuleResponse(ablyRule *control.Rule, plan *AblyRule) AblyRule {
 		respTarget = &AblyRuleTargetAMQPExternal{
 			Url:                types.StringValue(v.Url),
 			RoutingKey:         types.StringValue(v.RoutingKey),
-			Exchange:           types.StringValue(v.Exchange),
 			MandatoryRoute:     types.BoolValue(v.MandatoryRoute),
 			PersistentMessages: types.BoolValue(v.PersistentMessages),
 			MessageTtl:         ttl,
@@ -656,8 +661,8 @@ func ReadRule[T any](r Rule, ctx context.Context, req resource.ReadRequest, resp
 			return
 		}
 		resp.Diagnostics.AddError(
-			fmt.Sprintf("Error deleting Resource %s", r.Name()),
-			fmt.Sprintf("Could not delete resource %s, unexpected error: %s", r.Name(), err.Error()),
+			fmt.Sprintf("Error reading Resource %s", r.Name()),
+			fmt.Sprintf("Could not read resource %s, unexpected error: %s", r.Name(), err.Error()),
 		)
 		return
 	}


### PR DESCRIPTION
This enables us to take advantage of the provided retry logic.
By default it should make 4 attempts with an exponential backoff of up to 30 seconds.
This, in addition to internal changes to the API, closes #217.

Additionally, this PR fixes some bugs in tests for AMQP, Pulsar and Postgres rules, by removing the Exchange field in AMQP, preserving the TlsTrustCerts value in Pulsar to ensure the provider doesn't get confused when the API doesn't echo that field back, and updates test domains in Potgres rule tests since they now need to resolve to any valid IP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies to newer versions for improved stability and security.

* **Refactor**
  * Removed the AMQP external "exchange" attribute from the provider resource and examples, simplifying configuration.

* **Bug Fixes**
  * Preserve TLS trust certificates for Pulsar targets when reading plan data to avoid accidental loss.

* **Tests**
  * Updated Postgres connection URL fixtures to match new test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->