### PR TITLE
[INF-5286] Write reconciliation functions that pave over inconsistencies in API responses

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test
         run: |
           echo "provider_installation { dev_overrides { \"registry.terraform.io/ably/ably\" = \"$PWD/bin\", } direct {} }" > ~/.terraformrc
-          TF_ACC=1 go test -v -parallel 4 ./...
+          TF_ACC=1 go test -timeout 20m -v -parallel 4 ./...
         env:
           ABLY_ACCOUNT_TOKEN: ${{ secrets.ABLY_ACCOUNT_TOKEN }}
           ABLY_URL: 'https://staging-control.ably-dev.net/v1'

--- a/docs/resources/app.md
+++ b/docs/resources/app.md
@@ -55,7 +55,7 @@ resource "ably_app" "app1" {
 - `fcm_project_id` (String) The unique identifier for the Firebase Cloud Messaging(FCM) project. This ID is used to specify the Firebase project when configuring FCM or other Firebase services.
 - `fcm_service_account` (String, Sensitive) Used to specify the Firebase Cloud Messaging(FCM) service account credentials used for authentication and enabling communication with FCM to send push notifications to devices.
 - `status` (String) The application status. Disabled applications will not accept new connections and will return an error to all clients. When creating a new application, ensure that its status is set to enabled.
-- `tls_only` (Boolean) Enforce TLS for all connections. This setting overrides any channel setting.
+- `tls_only` (Boolean) Enforce TLS for all connections. This setting overrides any channel setting. When unset, the Control API's default applies.
 
 ### Read-Only
 

--- a/internal/exporter/config.go
+++ b/internal/exporter/config.go
@@ -167,7 +167,7 @@ func repairConfig(ctx context.Context, bridge *bridge, resourceType, label strin
 				"could not validate the generated config for %s.%s: %s", resourceType, label, err))
 		}
 
-		problems := errorDiagnostics(diagnostics)
+		problems := withoutWithheldRequired(schema, config, errorDiagnostics(diagnostics))
 		if len(problems) == 0 {
 			return config, dropped, unresolved
 		}
@@ -194,7 +194,7 @@ func repairConfig(ctx context.Context, bridge *bridge, resourceType, label strin
 	// up" leaves nothing to act on.
 	diagnostics, err := bridge.validate(ctx, resourceType, config)
 	if err == nil {
-		problems := errorDiagnostics(diagnostics)
+		problems := withoutWithheldRequired(schema, config, errorDiagnostics(diagnostics))
 		if len(problems) == 0 {
 			return config, dropped, unresolved
 		}
@@ -205,6 +205,32 @@ func repairConfig(ctx context.Context, bridge *bridge, resourceType, label strin
 	return config, dropped, append(unresolved, fmt.Sprintf(
 		"gave up repairing the generated config for %s.%s after %d attempts, and could not re-read why: %s",
 		resourceType, label, maxRepairs, err))
+}
+
+// withoutWithheldRequired drops the diagnostics raised against a required
+// attribute whose value the Control API withheld (Kafka SASL credentials, for
+// example, which the provider reads back as null).
+//
+// The provider rightly refuses a null required attribute, but the renderer
+// never writes that null: it writes a TODO, or a variable in vars mode, and
+// reports the gap in Missing. Repeating the provider's complaint as an
+// unfixable problem would bury that one actionable message under a second,
+// and its multi-line detail would land in the file as a broken comment.
+// Anything the provider objects to elsewhere is kept.
+func withoutWithheldRequired(schema *tfprotov6.Schema, config tftypes.Value, problems []*tfprotov6.Diagnostic) []*tfprotov6.Diagnostic {
+	var kept []*tfprotov6.Diagnostic
+	for _, problem := range problems {
+		if problem.Attribute != nil {
+			attribute := attributeAtPath(schema, problem.Attribute.Steps())
+			if attribute != nil && attribute.Required {
+				if current, err := valueAtPath(config, problem.Attribute.Steps()); err == nil && withheld(attribute, current) {
+					continue
+				}
+			}
+		}
+		kept = append(kept, problem)
+	}
+	return kept
 }
 
 // chooseRedundant picks the next deprecated attribute to remove: one the

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -269,7 +269,7 @@ func buildFiles(config Config, exports []exported, variables []variableDecl) []F
 		for _, export := range grouped[name] {
 			buf.WriteString("\n")
 			for _, note := range export.notes {
-				fmt.Fprintf(&buf, "# TODO: %s\n", note)
+				writeTODO(&buf, note)
 			}
 			buf.WriteString(export.hcl)
 		}
@@ -285,6 +285,22 @@ func buildFiles(config Config, exports []exported, variables []variableDecl) []F
 	}
 
 	return files
+}
+
+// writeTODO writes a note as a TODO comment. Provider diagnostics run to
+// several lines, and every one of them has to be commented or the file stops
+// being HCL.
+func writeTODO(buf *strings.Builder, note string) {
+	for index, line := range strings.Split(strings.TrimRight(note, "\n"), "\n") {
+		switch {
+		case index == 0:
+			fmt.Fprintf(buf, "# TODO: %s\n", line)
+		case strings.TrimSpace(line) == "":
+			buf.WriteString("#\n")
+		default:
+			fmt.Fprintf(buf, "# %s\n", line)
+		}
+	}
 }
 
 // generatedMarker opens every generated file, and is how WriteFiles recognises

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -594,6 +594,29 @@ func TestRunFlagsConfigItCannotRepair(t *testing.T) {
 	assertAssigns(t, config, "failed_action", `"not-a-valid-action"`)
 }
 
+// TestWriteTODOCommentsEveryLine covers a note carrying a multi-line provider
+// diagnostic: a bare continuation line would make the whole file invalid HCL.
+func TestWriteTODOCommentsEveryLine(t *testing.T) {
+	var buf strings.Builder
+	writeTODO(&buf, "the provider rejected the generated config for x.y, review it by hand: Missing value\n\nRefer to the provider documentation; and a second problem")
+	buf.WriteString("resource \"ably_app\" \"x\" {\n  name = \"x\"\n}\n")
+
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if strings.HasPrefix(line, "resource") || strings.HasPrefix(line, "  ") || line == "}" {
+			continue
+		}
+		if !strings.HasPrefix(line, "#") {
+			t.Errorf("line is not a comment: %q", line)
+		}
+	}
+	if !strings.HasPrefix(buf.String(), "# TODO: the provider rejected") {
+		t.Errorf("first line should carry the TODO marker:\n%s", buf.String())
+	}
+	if _, diagnostics := hclparse.NewParser().ParseHCL([]byte(buf.String()), "todo.tf"); diagnostics.HasErrors() {
+		t.Errorf("multi-line TODO produced invalid HCL: %s\n%s", diagnostics.Error(), buf.String())
+	}
+}
+
 // TestRunDoesNotWriteTheAccountID checks nothing identifying the account reaches
 // the output, which is meant to be committed.
 func TestRunDoesNotWriteTheAccountID(t *testing.T) {

--- a/internal/exporter/hcl.go
+++ b/internal/exporter/hcl.go
@@ -199,10 +199,11 @@ func (r *renderer) writeMissingRequired(buf *strings.Builder, depth int, attribu
 
 // withheld reports whether a value looks like one the Control API withheld.
 //
-// Null is the obvious case. An empty string counts only for sensitive
-// attributes: the provider maps absent credentials to "" rather than null (see
-// GetRuleResponse), and an empty credential is never intended. Elsewhere an empty
-// string can be legitimate.
+// Null is the usual case: the provider reconciles a credential the API did not
+// return to null (see GetRuleResponse). An empty string counts too, but only
+// for sensitive attributes: older provider builds mapped absent credentials to
+// "", and an empty credential is never intended. Elsewhere an empty string can
+// be legitimate.
 func withheld(attribute *tfprotov6.SchemaAttribute, value tftypes.Value) bool {
 	if value.IsNull() {
 		return true

--- a/internal/provider/fake_control_api_test.go
+++ b/internal/provider/fake_control_api_test.go
@@ -185,6 +185,27 @@ func (f *fakeControlAPI) handleMe(w http.ResponseWriter, _ *http.Request) {
 
 // --- apps ------------------------------------------------------------------
 
+// hermeticFake is the in-process Control API the suite runs against, or nil
+// when TF_ACC points the suite at a real Control API. Tests that need the API
+// to return something the provider would never send it (for example records
+// written by an older client) reach the fake through here, and must skip when
+// it is nil.
+var hermeticFake *fakeControlAPI
+
+// setAppField sets one JSON field on the stored app with the given name, as if
+// another client had written it. It reports whether such an app exists.
+func (f *fakeControlAPI) setAppField(appName, field string, value any) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, rec := range f.apps {
+		if rec["name"] == appName {
+			rec[field] = value
+			return true
+		}
+	}
+	return false
+}
+
 func (f *fakeControlAPI) createApp(w http.ResponseWriter, r *http.Request) {
 	body := fakeDecodeBody(r)
 	f.mu.Lock()
@@ -566,6 +587,7 @@ func TestMain(m *testing.M) {
 	var hermeticDir string
 	if tfAcc == "" {
 		fake = newFakeControlAPI()
+		hermeticFake = fake
 		_ = os.Setenv("ABLY_URL", fake.server.URL)
 		_ = os.Setenv("ABLY_ACCOUNT_TOKEN", "fake-token")
 		_ = os.Setenv("TF_ACC", "1")

--- a/internal/provider/helpers.go
+++ b/internal/provider/helpers.go
@@ -1,9 +1,28 @@
 package provider
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// recordCreatedIdentity stores the identity attributes of a freshly created
+// resource in the Create response state before any later step can fail.
+//
+// Once the remote create call has succeeded the resource exists whether or not
+// Create returns cleanly. If Create then returns an error with no state (a
+// read-back failure, or a reconciliation trip-wire), Terraform has no record
+// of the resource, and every retry creates and leaks another one. With the
+// identity recorded, Terraform instead marks the resource tainted and replaces
+// it on the next apply. The identity must be enough for Delete to work.
+func recordCreatedIdentity(ctx context.Context, resp *resource.CreateResponse, identity map[string]string) {
+	for name, value := range identity {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root(name), types.StringValue(value))...)
+	}
+}
 
 // ensureConfigured checks that the provider has been configured and appends an
 // error diagnostic if it has not. Returns true when the provider is ready,

--- a/internal/provider/ingress_rules.go
+++ b/internal/provider/ingress_rules.go
@@ -69,8 +69,13 @@ func GetPlanIngressRule(plan AblyIngressRule) (any, diag.Diagnostics) {
 // GetIngressRuleResponse maps an API rule response to the ingress rule terraform model.
 // Ingress rules use the same generic RuleResponse from the client, with target unmarshalled
 // according to the ruleType.
-func GetIngressRuleResponse(ablyRule *control.RuleResponse, plan *AblyIngressRule) (AblyIngressRule, diag.Diagnostics) {
+func GetIngressRuleResponse(ablyRule *control.RuleResponse, plan *AblyIngressRule, reading bool) (AblyIngressRule, diag.Diagnostics) {
 	var diags diag.Diagnostics
+	rc := newReconciler(&diags)
+	if reading {
+		rc.forRead()
+	}
+
 	var respTarget any
 
 	switch ablyRule.RuleType {
@@ -80,14 +85,18 @@ func GetIngressRuleResponse(ablyRule *control.RuleResponse, plan *AblyIngressRul
 			diags.AddError("Error unmarshalling ingress rule target", fmt.Sprintf("Could not unmarshal ingress/mongodb target: %s", err.Error()))
 			return AblyIngressRule{}, diags
 		}
+		var pt *AblyIngressRuleTargetMongo
+		if p, ok := plan.Target.(*AblyIngressRuleTargetMongo); ok {
+			pt = p
+		}
 		respTarget = &AblyIngressRuleTargetMongo{
-			Url:                      types.StringValue(target.URL),
-			Database:                 types.StringValue(target.Database),
-			Collection:               types.StringValue(target.Collection),
-			Pipeline:                 types.StringValue(target.Pipeline),
-			FullDocument:             types.StringValue(target.FullDocument),
-			FullDocumentBeforeChange: types.StringValue(target.FullDocumentBeforeChange),
-			PrimarySite:              types.StringValue(target.PrimarySite),
+			Url:                      rc.str("target.url", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.Url }), types.StringValue(target.URL), false),
+			Database:                 rc.str("target.database", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.Database }), types.StringValue(target.Database), false),
+			Collection:               rc.str("target.collection", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.Collection }), types.StringValue(target.Collection), false),
+			Pipeline:                 rc.str("target.pipeline", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.Pipeline }), types.StringValue(target.Pipeline), false),
+			FullDocument:             rc.str("target.full_document", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.FullDocument }), types.StringValue(target.FullDocument), false),
+			FullDocumentBeforeChange: rc.str("target.full_document_before_change", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.FullDocumentBeforeChange }), types.StringValue(target.FullDocumentBeforeChange), false),
+			PrimarySite:              rc.str("target.primary_site", planStr(pt, func(t *AblyIngressRuleTargetMongo) types.String { return t.PrimarySite }), types.StringValue(target.PrimarySite), false),
 		}
 	case "ingress-postgres-outbox":
 		target, err := unmarshalTarget[control.IngressPostgresOutboxTarget](ablyRule.Target)
@@ -95,15 +104,19 @@ func GetIngressRuleResponse(ablyRule *control.RuleResponse, plan *AblyIngressRul
 			diags.AddError("Error unmarshalling ingress rule target", fmt.Sprintf("Could not unmarshal ingress-postgres-outbox target: %s", err.Error()))
 			return AblyIngressRule{}, diags
 		}
+		var pt *AblyIngressRuleTargetPostgresOutbox
+		if p, ok := plan.Target.(*AblyIngressRuleTargetPostgresOutbox); ok {
+			pt = p
+		}
 		respTarget = &AblyIngressRuleTargetPostgresOutbox{
-			Url:               types.StringValue(target.URL),
-			OutboxTableSchema: types.StringValue(target.OutboxTableSchema),
-			OutboxTableName:   types.StringValue(target.OutboxTableName),
-			NodesTableSchema:  types.StringValue(target.NodesTableSchema),
-			NodesTableName:    types.StringValue(target.NodesTableName),
-			SslMode:           types.StringValue(target.SSLMode),
-			SslRootCert:       optStringValue(target.SSLRootCert),
-			PrimarySite:       types.StringValue(target.PrimarySite),
+			Url:               rc.str("target.url", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.Url }), types.StringValue(target.URL), false),
+			OutboxTableSchema: rc.str("target.outbox_table_schema", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.OutboxTableSchema }), types.StringValue(target.OutboxTableSchema), false),
+			OutboxTableName:   rc.str("target.outbox_table_name", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.OutboxTableName }), types.StringValue(target.OutboxTableName), false),
+			NodesTableSchema:  rc.str("target.nodes_table_schema", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.NodesTableSchema }), types.StringValue(target.NodesTableSchema), false),
+			NodesTableName:    rc.str("target.nodes_table_name", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.NodesTableName }), types.StringValue(target.NodesTableName), false),
+			SslMode:           rc.str("target.ssl_mode", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.SslMode }), types.StringValue(target.SSLMode), false),
+			SslRootCert:       rc.str("target.ssl_root_cert", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.SslRootCert }), optStringValue(target.SSLRootCert), false),
+			PrimarySite:       rc.str("target.primary_site", planStr(pt, func(t *AblyIngressRuleTargetPostgresOutbox) types.String { return t.PrimarySite }), types.StringValue(target.PrimarySite), false),
 		}
 	default:
 		diags.AddError(
@@ -114,9 +127,9 @@ func GetIngressRuleResponse(ablyRule *control.RuleResponse, plan *AblyIngressRul
 	}
 
 	respRule := AblyIngressRule{
-		ID:     types.StringValue(ablyRule.ID),
-		AppID:  types.StringValue(ablyRule.AppID),
-		Status: types.StringValue(ablyRule.Status),
+		ID:     rc.str("id", plan.ID, types.StringValue(ablyRule.ID), true),
+		AppID:  rc.str("app_id", plan.AppID, types.StringValue(ablyRule.AppID), false),
+		Status: rc.str("status", plan.Status, types.StringValue(ablyRule.Status), true),
 		Target: respTarget,
 	}
 
@@ -188,7 +201,7 @@ func CreateIngressRule[T any](r Rule, ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	responseValues, respDiags := GetIngressRuleResponse(&rule, &plan)
+	responseValues, respDiags := GetIngressRuleResponse(&rule, &plan, false)
 	resp.Diagnostics.Append(respDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -232,7 +245,7 @@ func ReadIngressRule[T any](r Rule, ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	responseValues, respDiags := GetIngressRuleResponse(&rule, &state)
+	responseValues, respDiags := GetIngressRuleResponse(&rule, &state, true)
 	resp.Diagnostics.Append(respDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -278,7 +291,7 @@ func UpdateIngressRule[T any](r Rule, ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	responseValues, respDiags := GetIngressRuleResponse(&rule, &plan)
+	responseValues, respDiags := GetIngressRuleResponse(&rule, &plan, false)
 	resp.Diagnostics.Append(respDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/ingress_rules.go
+++ b/internal/provider/ingress_rules.go
@@ -66,61 +66,63 @@ func GetPlanIngressRule(plan AblyIngressRule) (any, diag.Diagnostics) {
 	return nil, diags
 }
 
-// GetIngressRuleResponse maps an API rule response to the ingress rule terraform model.
-// Ingress rules use the same generic RuleResponse from the client, with target unmarshalled
-// according to the ruleType.
-func GetIngressRuleResponse(ablyRule *control.RuleResponse, plan *AblyIngressRule) (AblyIngressRule, diag.Diagnostics) {
-	var diags diag.Diagnostics
+// GetIngressRuleResponse maps an API rule response onto the ingress rule
+// resource schema. Ingress rules share the generic RuleResponse, with the
+// target unmarshalled according to the rule type. See GetRuleResponse for the
+// reconciliation contract.
+func GetIngressRuleResponse(rc *reconciler, ablyRule *control.RuleResponse, plan *AblyIngressRule) AblyIngressRule {
 	var respTarget any
 
 	switch ablyRule.RuleType {
 	case "ingress/mongodb":
 		target, err := unmarshalTarget[control.IngressMongoDBTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling ingress rule target", fmt.Sprintf("Could not unmarshal ingress/mongodb target: %s", err.Error()))
-			return AblyIngressRule{}, diags
+			rc.diags.AddError("Error unmarshalling ingress rule target", fmt.Sprintf("Could not unmarshal ingress/mongodb target: %s", err.Error()))
+			return AblyIngressRule{}
 		}
+		pt := planTarget[AblyIngressRuleTargetMongo](plan.Target)
 		respTarget = &AblyIngressRuleTargetMongo{
-			Url:                      types.StringValue(target.URL),
-			Database:                 types.StringValue(target.Database),
-			Collection:               types.StringValue(target.Collection),
-			Pipeline:                 types.StringValue(target.Pipeline),
-			FullDocument:             types.StringValue(target.FullDocument),
-			FullDocumentBeforeChange: types.StringValue(target.FullDocumentBeforeChange),
-			PrimarySite:              types.StringValue(target.PrimarySite),
+			Url:                      rcVal(rc, "target.url", pt.Url, types.StringValue(target.URL), false),
+			Database:                 rcVal(rc, "target.database", pt.Database, types.StringValue(target.Database), false),
+			Collection:               rcVal(rc, "target.collection", pt.Collection, types.StringValue(target.Collection), false),
+			Pipeline:                 rcVal(rc, "target.pipeline", pt.Pipeline, types.StringValue(target.Pipeline), false),
+			FullDocument:             rcVal(rc, "target.full_document", pt.FullDocument, types.StringValue(target.FullDocument), false),
+			FullDocumentBeforeChange: rcVal(rc, "target.full_document_before_change", pt.FullDocumentBeforeChange, types.StringValue(target.FullDocumentBeforeChange), false),
+			PrimarySite:              rcVal(rc, "target.primary_site", pt.PrimarySite, types.StringValue(target.PrimarySite), false),
 		}
 	case "ingress-postgres-outbox":
 		target, err := unmarshalTarget[control.IngressPostgresOutboxTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling ingress rule target", fmt.Sprintf("Could not unmarshal ingress-postgres-outbox target: %s", err.Error()))
-			return AblyIngressRule{}, diags
+			rc.diags.AddError("Error unmarshalling ingress rule target", fmt.Sprintf("Could not unmarshal ingress-postgres-outbox target: %s", err.Error()))
+			return AblyIngressRule{}
 		}
+		pt := planTarget[AblyIngressRuleTargetPostgresOutbox](plan.Target)
 		respTarget = &AblyIngressRuleTargetPostgresOutbox{
-			Url:               types.StringValue(target.URL),
-			OutboxTableSchema: types.StringValue(target.OutboxTableSchema),
-			OutboxTableName:   types.StringValue(target.OutboxTableName),
-			NodesTableSchema:  types.StringValue(target.NodesTableSchema),
-			NodesTableName:    types.StringValue(target.NodesTableName),
-			SslMode:           types.StringValue(target.SSLMode),
-			SslRootCert:       optStringValue(target.SSLRootCert),
-			PrimarySite:       types.StringValue(target.PrimarySite),
+			Url:               rcVal(rc, "target.url", pt.Url, types.StringValue(target.URL), false),
+			OutboxTableSchema: rcVal(rc, "target.outbox_table_schema", pt.OutboxTableSchema, types.StringValue(target.OutboxTableSchema), false),
+			OutboxTableName:   rcVal(rc, "target.outbox_table_name", pt.OutboxTableName, types.StringValue(target.OutboxTableName), false),
+			NodesTableSchema:  rcVal(rc, "target.nodes_table_schema", pt.NodesTableSchema, types.StringValue(target.NodesTableSchema), false),
+			NodesTableName:    rcVal(rc, "target.nodes_table_name", pt.NodesTableName, types.StringValue(target.NodesTableName), false),
+			SslMode:           rcVal(rc, "target.ssl_mode", pt.SslMode, types.StringValue(target.SSLMode), false),
+			SslRootCert:       rcVal(rc, "target.ssl_root_cert", pt.SslRootCert, optStringValue(target.SSLRootCert), false),
+			PrimarySite:       rcVal(rc, "target.primary_site", pt.PrimarySite, types.StringValue(target.PrimarySite), false),
 		}
 	default:
-		diags.AddError(
+		rc.diags.AddError(
 			"Unknown ingress rule type in response",
 			fmt.Sprintf("Received unrecognized ingress rule type from API: %q", ablyRule.RuleType),
 		)
-		return AblyIngressRule{}, diags
+		return AblyIngressRule{}
 	}
 
 	respRule := AblyIngressRule{
-		ID:     types.StringValue(ablyRule.ID),
-		AppID:  types.StringValue(ablyRule.AppID),
-		Status: types.StringValue(ablyRule.Status),
+		ID:     rcVal(rc, "id", plan.ID, types.StringValue(ablyRule.ID), true),
+		AppID:  rcVal(rc, "app_id", plan.AppID, types.StringValue(ablyRule.AppID), false),
+		Status: rcVal(rc, "status", plan.Status, types.StringValue(ablyRule.Status), true),
 		Target: respTarget,
 	}
 
-	return respRule, diags
+	return respRule
 }
 
 func GetIngressRuleSchema(target map[string]schema.Attribute, markdownDescription string) schema.Schema {
@@ -187,9 +189,9 @@ func CreateIngressRule[T any](r Rule, ctx context.Context, req resource.CreateRe
 		)
 		return
 	}
+	recordCreatedIdentity(ctx, resp, map[string]string{"app_id": plan.AppID.ValueString(), "id": rule.ID})
 
-	responseValues, respDiags := GetIngressRuleResponse(&rule, &plan)
-	resp.Diagnostics.Append(respDiags...)
+	responseValues := GetIngressRuleResponse(newReconciler(&resp.Diagnostics), &rule, &plan)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -232,8 +234,7 @@ func ReadIngressRule[T any](r Rule, ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	responseValues, respDiags := GetIngressRuleResponse(&rule, &state)
-	resp.Diagnostics.Append(respDiags...)
+	responseValues := GetIngressRuleResponse(newReconciler(&resp.Diagnostics).forRead(), &rule, &state)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -278,8 +279,7 @@ func UpdateIngressRule[T any](r Rule, ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	responseValues, respDiags := GetIngressRuleResponse(&rule, &plan)
-	resp.Diagnostics.Append(respDiags...)
+	responseValues := GetIngressRuleResponse(newReconciler(&resp.Diagnostics), &rule, &plan)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/modifiers.go
+++ b/internal/provider/modifiers.go
@@ -24,13 +24,12 @@ func (m defaultBoolModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultBoolModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
-		return
+	if req.ConfigValue.IsNull() && (resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown()) {
+		resp.PlanValue = m.value
 	}
-	resp.PlanValue = m.value
 }
 
 // DefaultBoolAttribute returns a plan modifier that sets a default bool value.
@@ -52,13 +51,12 @@ func (m defaultInt64Modifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
-		return
+	if req.ConfigValue.IsNull() && (resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown()) {
+		resp.PlanValue = m.value
 	}
-	resp.PlanValue = m.value
 }
 
 // DefaultInt64Attribute returns a plan modifier that sets a default int64 value.
@@ -80,13 +78,15 @@ func (m defaultStringModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
-		return
+	// Set default when config is null and the plan doesn't already carry
+	// a concrete value (e.g. from prior state). This covers both Create
+	// (PlanValue is Unknown for Computed fields) and Update with null state.
+	if req.ConfigValue.IsNull() && (resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown()) {
+		resp.PlanValue = m.value
 	}
-	resp.PlanValue = m.value
 }
 
 // DefaultStringAttribute returns a plan modifier that sets a default string value.

--- a/internal/provider/modifiers.go
+++ b/internal/provider/modifiers.go
@@ -25,13 +25,12 @@ func (m defaultBoolModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultBoolModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
-		return
+	if req.ConfigValue.IsNull() && (resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown()) {
+		resp.PlanValue = m.value
 	}
-	resp.PlanValue = m.value
 }
 
 // DefaultBoolAttribute returns a plan modifier that sets a default bool value.
@@ -109,13 +108,12 @@ func (m defaultInt64Modifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
-		return
+	if req.ConfigValue.IsNull() && (resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown()) {
+		resp.PlanValue = m.value
 	}
-	resp.PlanValue = m.value
 }
 
 // DefaultInt64Attribute returns a plan modifier that sets a default int64 value.
@@ -137,13 +135,15 @@ func (m defaultStringModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if req.ConfigValue.IsUnknown() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
-		return
+	// Set default when config is null and the plan doesn't already carry
+	// a concrete value (e.g. from prior state). This covers both Create
+	// (PlanValue is Unknown for Computed fields) and Update with null state.
+	if req.ConfigValue.IsNull() && (resp.PlanValue.IsNull() || resp.PlanValue.IsUnknown()) {
+		resp.PlanValue = m.value
 	}
-	resp.PlanValue = m.value
 }
 
 // DefaultStringAttribute returns a plan modifier that sets a default string value.

--- a/internal/provider/modifiers.go
+++ b/internal/provider/modifiers.go
@@ -11,7 +11,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// defaultBoolModifier implements planmodifier.Bool using the built-in pattern.
+// The default* modifiers implement "default on create, keep on update" for
+// Optional+Computed attributes:
+//
+//   - configured (known or unknown): the configured value stands;
+//   - not configured and no prior state (Create, or a replacement): the default;
+//   - not configured with prior state (Update): the prior state value.
+//
+// The last rule matters because the framework marks an unconfigured computed
+// attribute unknown whenever anything else in the resource changes, and the
+// CRUD code serialises plan values into requests. Re-applying the default there
+// would send it to the API on every unrelated update, silently overwriting a
+// value set server-side or out of band (an app's tls_only, a namespace flag, an
+// imported rule's request_mode). Keeping the prior state value instead mirrors
+// UseStateForUnknown, so a refreshed state round-trips unchanged.
+
+// defaultBoolModifier implements planmodifier.Bool.
 type defaultBoolModifier struct {
 	value types.Bool
 }
@@ -25,13 +40,16 @@ func (m defaultBoolModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultBoolModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if !req.ConfigValue.IsNull() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
+	if req.StateValue.IsNull() {
+		resp.PlanValue = m.value
 		return
 	}
-	resp.PlanValue = m.value
+	if resp.PlanValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+	}
 }
 
 // DefaultBoolAttribute returns a plan modifier that sets a default bool value.
@@ -109,13 +127,16 @@ func (m defaultInt64Modifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if !req.ConfigValue.IsNull() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
+	if req.StateValue.IsNull() {
+		resp.PlanValue = m.value
 		return
 	}
-	resp.PlanValue = m.value
+	if resp.PlanValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+	}
 }
 
 // DefaultInt64Attribute returns a plan modifier that sets a default int64 value.
@@ -137,13 +158,16 @@ func (m defaultStringModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m defaultStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if resp.PlanValue.IsUnknown() || req.ConfigValue.IsUnknown() {
+	if !req.ConfigValue.IsNull() {
 		return
 	}
-	if !req.ConfigValue.IsNull() || !req.PlanValue.IsNull() {
+	if req.StateValue.IsNull() {
+		resp.PlanValue = m.value
 		return
 	}
-	resp.PlanValue = m.value
+	if resp.PlanValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+	}
 }
 
 // DefaultStringAttribute returns a plan modifier that sets a default string value.

--- a/internal/provider/modifiers_test.go
+++ b/internal/provider/modifiers_test.go
@@ -1,0 +1,100 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// The default* modifiers must apply their default only when Terraform has no
+// prior value for the attribute. On an update they keep the prior state value,
+// because the CRUD code serialises plan values into requests and re-sending
+// the default would overwrite a server-side or out-of-band value on every
+// unrelated change.
+func TestDefaultBoolAttribute(t *testing.T) {
+	t.Parallel()
+
+	def := types.BoolValue(true)
+	cases := []struct {
+		name   string
+		config types.Bool
+		state  types.Bool
+		plan   types.Bool
+		want   types.Bool
+	}{
+		{name: "create, unconfigured: default", config: types.BoolNull(), state: types.BoolNull(), plan: types.BoolUnknown(), want: def},
+		{name: "update, unconfigured, unknown plan: prior state", config: types.BoolNull(), state: types.BoolValue(false), plan: types.BoolUnknown(), want: types.BoolValue(false)},
+		{name: "no-op update, unconfigured: plan already carries state", config: types.BoolNull(), state: types.BoolValue(false), plan: types.BoolValue(false), want: types.BoolValue(false)},
+		{name: "configured: config wins over default and state", config: types.BoolValue(false), state: types.BoolValue(true), plan: types.BoolValue(false), want: types.BoolValue(false)},
+		{name: "unknown config: left unknown", config: types.BoolUnknown(), state: types.BoolValue(true), plan: types.BoolUnknown(), want: types.BoolUnknown()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := planmodifier.BoolRequest{ConfigValue: tc.config, StateValue: tc.state, PlanValue: tc.plan}
+			resp := planmodifier.BoolResponse{PlanValue: tc.plan}
+			DefaultBoolAttribute(def).PlanModifyBool(context.Background(), req, &resp)
+			if !resp.PlanValue.Equal(tc.want) {
+				t.Fatalf("expected %s, got %s", tc.want, resp.PlanValue)
+			}
+		})
+	}
+}
+
+func TestDefaultStringAttribute(t *testing.T) {
+	t.Parallel()
+
+	def := types.StringValue("single")
+	cases := []struct {
+		name   string
+		config types.String
+		state  types.String
+		plan   types.String
+		want   types.String
+	}{
+		{name: "create, unconfigured: default", config: types.StringNull(), state: types.StringNull(), plan: types.StringUnknown(), want: def},
+		{name: "update, unconfigured, unknown plan: prior state", config: types.StringNull(), state: types.StringValue("batch"), plan: types.StringUnknown(), want: types.StringValue("batch")},
+		{name: "configured: config wins", config: types.StringValue("batch"), state: types.StringValue("single"), plan: types.StringValue("batch"), want: types.StringValue("batch")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := planmodifier.StringRequest{ConfigValue: tc.config, StateValue: tc.state, PlanValue: tc.plan}
+			resp := planmodifier.StringResponse{PlanValue: tc.plan}
+			DefaultStringAttribute(def).PlanModifyString(context.Background(), req, &resp)
+			if !resp.PlanValue.Equal(tc.want) {
+				t.Fatalf("expected %s, got %s", tc.want, resp.PlanValue)
+			}
+		})
+	}
+}
+
+func TestDefaultInt64Attribute(t *testing.T) {
+	t.Parallel()
+
+	def := types.Int64Value(0)
+	cases := []struct {
+		name   string
+		config types.Int64
+		state  types.Int64
+		plan   types.Int64
+		want   types.Int64
+	}{
+		{name: "create, unconfigured: default", config: types.Int64Null(), state: types.Int64Null(), plan: types.Int64Unknown(), want: def},
+		{name: "update, unconfigured, unknown plan: prior state", config: types.Int64Null(), state: types.Int64Value(1), plan: types.Int64Unknown(), want: types.Int64Value(1)},
+		{name: "configured: config wins", config: types.Int64Value(7), state: types.Int64Value(1), plan: types.Int64Value(7), want: types.Int64Value(7)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := planmodifier.Int64Request{ConfigValue: tc.config, StateValue: tc.state, PlanValue: tc.plan}
+			resp := planmodifier.Int64Response{PlanValue: tc.plan}
+			DefaultInt64Attribute(def).PlanModifyInt64(context.Background(), req, &resp)
+			if !resp.PlanValue.Equal(tc.want) {
+				t.Fatalf("expected %s, got %s", tc.want, resp.PlanValue)
+			}
+		})
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,6 +2,7 @@
 package provider
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -21,4 +22,54 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("ABLY_ACCOUNT_TOKEN"); v == "" {
 		t.Fatal("ABLY_ACCOUNT_TOKEN must be set for acceptance tests")
 	}
+}
+
+// tfProvider is the shared Terraform provider configuration block used by
+// minimal-config acceptance tests across resource test files.
+const tfProvider = `
+terraform {
+	required_providers {
+		ably = {
+			source = "registry.terraform.io/ably/ably"
+		}
+	}
+}
+provider "ably" {}
+`
+
+// minimalRuleConfig builds an HCL config with only required fields for a rule
+// resource. The targetHCL argument is the target block content specific to
+// each rule type.
+func minimalRuleConfig(appName, resourceType, targetHCL string) string {
+	return fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource %q "rule0" {
+	app_id = ably_app.app0.id
+
+	source = {
+		type = "channel.message"
+	}
+
+	%s
+}
+`, tfProvider, appName, resourceType, targetHCL)
+}
+
+// minimalIngressRuleConfig builds an HCL config with only required fields for
+// an ingress rule resource.
+func minimalIngressRuleConfig(appName, resourceType, targetHCL string) string {
+	return fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource %q "rule0" {
+	app_id = ably_app.app0.id
+
+	%s
+}
+`, tfProvider, appName, resourceType, targetHCL)
 }

--- a/internal/provider/reconcile.go
+++ b/internal/provider/reconcile.go
@@ -1,0 +1,249 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// reconciler accumulates diagnostics so callers can reconcile many fields
+// without checking errors after each one.
+//
+// When reading is true (set via forRead), every field is treated as computed
+// so the API response is always accepted. This is necessary because during
+// Read (including import), the prior state may be empty — there is no user
+// plan to compare against.
+type reconciler struct {
+	diags   *diag.Diagnostics
+	reading bool
+}
+
+func newReconciler(diags *diag.Diagnostics) *reconciler {
+	return &reconciler{diags: diags}
+}
+
+func (r *reconciler) forRead() *reconciler {
+	r.reading = true
+	return r
+}
+
+func (r *reconciler) str(field string, input, output types.String, computed bool) types.String {
+	v, err := reconcileString(field, input, output, computed || r.reading)
+	if err != nil {
+		r.diags.AddError("State reconciliation error", err.Error())
+	}
+	return v
+}
+
+func (r *reconciler) boolean(field string, input, output types.Bool, computed bool) types.Bool {
+	v, err := reconcileBool(field, input, output, computed || r.reading)
+	if err != nil {
+		r.diags.AddError("State reconciliation error", err.Error())
+	}
+	return v
+}
+
+func (r *reconciler) int64val(field string, input, output types.Int64, computed bool) types.Int64 {
+	v, err := reconcileInt64(field, input, output, computed || r.reading)
+	if err != nil {
+		r.diags.AddError("State reconciliation error", err.Error())
+	}
+	return v
+}
+
+// reconcileSlice reconciles a plan/state slice with an API response slice.
+// Go does not allow generic methods on structs, so this is a standalone helper
+// that takes the reconciler for diagnostics and reading mode.
+func reconcileSlice[T any](field string, input, output []T, computed bool) ([]T, error) {
+	inputEmpty := len(input) == 0
+	outputEmpty := len(output) == 0
+
+	switch {
+	case !inputEmpty && !outputEmpty:
+		return output, nil
+	case !inputEmpty && outputEmpty:
+		return input, nil
+	case inputEmpty && !outputEmpty:
+		if computed {
+			return output, nil
+		}
+		return nil, fmt.Errorf(
+			"reconcile %q: API returned %d elements but field was not set in config and is not computed",
+			field, len(output),
+		)
+	default:
+		return nil, nil
+	}
+}
+
+// rcSlice is the reconciler-aware wrapper for reconcileSlice.
+func rcSlice[T any](rc *reconciler, field string, input, output []T, computed bool) []T {
+	v, err := reconcileSlice(field, input, output, computed || rc.reading)
+	if err != nil {
+		rc.diags.AddError("State reconciliation error", err.Error())
+	}
+	return v
+}
+
+// reconcileMapSet reconciles a plan/state map[string]types.Set with an API response map.
+func reconcileMapSet(field string, input, output map[string]types.Set, computed bool) (map[string]types.Set, error) {
+	inputEmpty := len(input) == 0
+	outputEmpty := len(output) == 0
+
+	switch {
+	case !inputEmpty && !outputEmpty:
+		return output, nil
+	case !inputEmpty && outputEmpty:
+		return input, nil
+	case inputEmpty && !outputEmpty:
+		if computed {
+			return output, nil
+		}
+		return nil, fmt.Errorf(
+			"reconcile %q: API returned %d entries but field was not set in config and is not computed",
+			field, len(output),
+		)
+	default:
+		return nil, nil
+	}
+}
+
+func (r *reconciler) mapSet(field string, input, output map[string]types.Set, computed bool) map[string]types.Set {
+	v, err := reconcileMapSet(field, input, output, computed || r.reading)
+	if err != nil {
+		r.diags.AddError("State reconciliation error", err.Error())
+	}
+	return v
+}
+
+// --- Plan field accessors ---
+// These extract a typed field from a possibly-nil plan target pointer.
+// When the plan target is nil (e.g. during import or type mismatch),
+// they return the zero value which reconcile treats as empty/null.
+
+func planStr[T any](pt *T, fn func(*T) types.String) types.String {
+	if pt == nil {
+		return types.StringNull()
+	}
+	return fn(pt)
+}
+
+func planBool[T any](pt *T, fn func(*T) types.Bool) types.Bool {
+	if pt == nil {
+		return types.BoolNull()
+	}
+	return fn(pt)
+}
+
+func planInt64[T any](pt *T, fn func(*T) types.Int64) types.Int64 {
+	if pt == nil {
+		return types.Int64Null()
+	}
+	return fn(pt)
+}
+
+func planSlice[T any, E any](pt *T, fn func(*T) []E) []E {
+	if pt == nil {
+		return nil
+	}
+	return fn(pt)
+}
+
+// optIntFromIntPtr converts a *int to types.Int64, returning types.Int64Null() when nil.
+func optIntFromIntPtr(i *int) types.Int64 {
+	if i == nil {
+		return types.Int64Null()
+	}
+	return types.Int64Value(int64(*i))
+}
+
+// optStringValue converts a non-pointer string to types.String, treating "" as null.
+// For pointer strings, use the existing optStringValue in helpers.go.
+func optStringFromString(s string) types.String {
+	if s == "" {
+		return types.StringNull()
+	}
+	return types.StringValue(s)
+}
+
+// Reconcile functions handle the four-way matrix of input (plan/state) vs
+// output (API response) emptiness:
+//
+//  1. Input non-empty, Output non-empty → return output (API is authoritative)
+//  2. Input non-empty, Output empty     → return input  (write-only / sensitive field)
+//  3. Input empty,     Output non-empty:
+//     - computed=true  → return output (server-owned or defaulted field)
+//     - computed=false → return error  (unexpected value for optional-only field)
+//  4. Input empty,     Output empty     → return null
+//
+// "Empty" means null, unknown, or (for strings) the zero-length string "".
+
+// reconcileString reconciles a plan/state string with an API response string.
+func reconcileString(field string, input, output types.String, computed bool) (types.String, error) {
+	inputEmpty := input.IsNull() || input.IsUnknown() || input.ValueString() == ""
+	outputEmpty := output.IsNull() || output.IsUnknown() || output.ValueString() == ""
+
+	switch {
+	case !inputEmpty && !outputEmpty:
+		return output, nil
+	case !inputEmpty && outputEmpty:
+		return input, nil
+	case inputEmpty && !outputEmpty:
+		if computed {
+			return output, nil
+		}
+		return types.StringNull(), fmt.Errorf(
+			"reconcile %q: API returned %q but field was not set in config and is not computed",
+			field, output.ValueString(),
+		)
+	default:
+		return types.StringNull(), nil
+	}
+}
+
+// reconcileBool reconciles a plan/state bool with an API response bool.
+func reconcileBool(field string, input, output types.Bool, computed bool) (types.Bool, error) {
+	inputEmpty := input.IsNull() || input.IsUnknown()
+	outputEmpty := output.IsNull() || output.IsUnknown()
+
+	switch {
+	case !inputEmpty && !outputEmpty:
+		return output, nil
+	case !inputEmpty && outputEmpty:
+		return input, nil
+	case inputEmpty && !outputEmpty:
+		if computed {
+			return output, nil
+		}
+		return types.BoolNull(), fmt.Errorf(
+			"reconcile %q: API returned %t but field was not set in config and is not computed",
+			field, output.ValueBool(),
+		)
+	default:
+		return types.BoolNull(), nil
+	}
+}
+
+// reconcileInt64 reconciles a plan/state int64 with an API response int64.
+func reconcileInt64(field string, input, output types.Int64, computed bool) (types.Int64, error) {
+	inputEmpty := input.IsNull() || input.IsUnknown()
+	outputEmpty := output.IsNull() || output.IsUnknown()
+
+	switch {
+	case !inputEmpty && !outputEmpty:
+		return output, nil
+	case !inputEmpty && outputEmpty:
+		return input, nil
+	case inputEmpty && !outputEmpty:
+		if computed {
+			return output, nil
+		}
+		return types.Int64Null(), fmt.Errorf(
+			"reconcile %q: API returned %d but field was not set in config and is not computed",
+			field, output.ValueInt64(),
+		)
+	default:
+		return types.Int64Null(), nil
+	}
+}

--- a/internal/provider/reconcile.go
+++ b/internal/provider/reconcile.go
@@ -150,23 +150,6 @@ func planSlice[T any, E any](pt *T, fn func(*T) []E) []E {
 	return fn(pt)
 }
 
-// optIntFromIntPtr converts a *int to types.Int64, returning types.Int64Null() when nil.
-func optIntFromIntPtr(i *int) types.Int64 {
-	if i == nil {
-		return types.Int64Null()
-	}
-	return types.Int64Value(int64(*i))
-}
-
-// optStringValue converts a non-pointer string to types.String, treating "" as null.
-// For pointer strings, use the existing optStringValue in helpers.go.
-func optStringFromString(s string) types.String {
-	if s == "" {
-		return types.StringNull()
-	}
-	return types.StringValue(s)
-}
-
 // Reconcile functions handle the four-way matrix of input (plan/state) vs
 // output (API response) emptiness:
 //

--- a/internal/provider/reconcile.go
+++ b/internal/provider/reconcile.go
@@ -193,9 +193,12 @@ func reconcileString(field string, input, output types.String, computed bool) (t
 		if computed {
 			return output, nil
 		}
+		// Deliberately omit the returned value: string fields can carry
+		// secrets (keys, tokens, header values) that must not leak into
+		// diagnostics or logs.
 		return types.StringNull(), fmt.Errorf(
-			"reconcile %q: API returned %q but field was not set in config and is not computed",
-			field, output.ValueString(),
+			"reconcile %q: API returned a value but field was not set in config and is not computed",
+			field,
 		)
 	default:
 		return types.StringNull(), nil

--- a/internal/provider/reconcile.go
+++ b/internal/provider/reconcile.go
@@ -1,0 +1,148 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Reconciliation decides, field by field, what to store in state after an API
+// call by comparing the input (the plan on Create/Update, the prior state on
+// Read) with the output (the API response). It resolves the four-way matrix of
+// input/output emptiness:
+//
+//  1. Input non-empty, Output non-empty → output (the API is authoritative)
+//  2. Input non-empty, Output empty     → input  (write-only / sensitive field)
+//  3. Input empty,     Output non-empty:
+//     - computed=true  → output (server-owned or defaulted field)
+//     - computed=false → error  (unexpected value for an optional-only field)
+//  4. Input empty,     Output empty     → null
+//
+// "Empty" means null or unknown, the zero-length string for strings, and zero
+// length for slices and maps. false and 0 are real values, not empty.
+//
+// The matrix is implemented once, in reconcile; the typed helpers above it only
+// decide emptiness for their kind.
+
+// reconciler accumulates diagnostics so callers can reconcile many fields
+// without checking errors after each one.
+//
+// When reading is true (set via forRead), every field is treated as computed
+// so the API response is always accepted. This is necessary because during
+// Read (including import), the prior state may be empty — there is no user
+// plan to compare against.
+type reconciler struct {
+	diags   *diag.Diagnostics
+	reading bool
+}
+
+func newReconciler(diags *diag.Diagnostics) *reconciler {
+	return &reconciler{diags: diags}
+}
+
+func (r *reconciler) forRead() *reconciler {
+	r.reading = true
+	return r
+}
+
+// record folds a reconciliation error into the accumulated diagnostics.
+func (r *reconciler) record(err error) {
+	if err != nil {
+		r.diags.AddError("State reconciliation error", err.Error())
+	}
+}
+
+// Go does not allow generic methods, so the reconciler-aware entry points are
+// free functions that take the reconciler as their first argument.
+
+// rcVal reconciles a scalar (string, bool or int64) field.
+func rcVal[V scalarValue](rc *reconciler, field string, input, output V, computed bool) V {
+	v, err := reconcileValue(field, input, output, computed || rc.reading)
+	rc.record(err)
+	return v
+}
+
+// rcSlice reconciles a slice field.
+func rcSlice[E any](rc *reconciler, field string, input, output []E, computed bool) []E {
+	v, err := reconcileSlice(field, input, output, computed || rc.reading)
+	rc.record(err)
+	return v
+}
+
+// rcMapSet reconciles a map[string]types.Set field.
+func rcMapSet(rc *reconciler, field string, input, output map[string]types.Set, computed bool) map[string]types.Set {
+	v, err := reconcileMapSet(field, input, output, computed || rc.reading)
+	rc.record(err)
+	return v
+}
+
+// planTarget extracts the typed plan target of a rule, or a zero-value one when
+// the plan carries none (import) or one of a different type. Every field of the
+// zero value is null (or a nil slice), which reconciliation treats as empty, so
+// callers can read fields directly without nil checks.
+func planTarget[T any](target any) *T {
+	if p, ok := target.(*T); ok && p != nil {
+		return p
+	}
+	return new(T)
+}
+
+// scalarValue is the set of framework scalar types reconcileValue accepts.
+type scalarValue interface {
+	types.String | types.Bool | types.Int64
+	attr.Value
+}
+
+// valueEmpty reports whether a scalar is empty: null, unknown, or (for
+// strings) the zero-length string.
+func valueEmpty[V scalarValue](v V) bool {
+	if v.IsNull() || v.IsUnknown() {
+		return true
+	}
+	s, ok := any(v).(types.String)
+	return ok && s.ValueString() == ""
+}
+
+// reconcileValue reconciles a plan/state scalar with an API response scalar.
+func reconcileValue[V scalarValue](field string, input, output V, computed bool) (V, error) {
+	return reconcile(field, input, output, valueEmpty(input), valueEmpty(output), computed)
+}
+
+// reconcileSlice reconciles a plan/state slice with an API response slice.
+func reconcileSlice[E any](field string, input, output []E, computed bool) ([]E, error) {
+	return reconcile(field, input, output, len(input) == 0, len(output) == 0, computed)
+}
+
+// reconcileMapSet reconciles a plan/state map[string]types.Set with an API
+// response map.
+func reconcileMapSet(field string, input, output map[string]types.Set, computed bool) (map[string]types.Set, error) {
+	return reconcile(field, input, output, len(input) == 0, len(output) == 0, computed)
+}
+
+// reconcile is the single implementation of the four-way matrix documented at
+// the top of this file. Emptiness is decided by the typed callers; the zero
+// value of T is null for framework scalars and nil for collections.
+//
+// The error deliberately omits the returned value: fields can carry secrets
+// (keys, tokens, header values) that must not leak into diagnostics or logs.
+func reconcile[T any](field string, input, output T, inputEmpty, outputEmpty, computed bool) (T, error) {
+	var null T
+	switch {
+	case !inputEmpty && !outputEmpty:
+		return output, nil
+	case !inputEmpty && outputEmpty:
+		return input, nil
+	case inputEmpty && !outputEmpty:
+		if computed {
+			return output, nil
+		}
+		return null, fmt.Errorf(
+			"reconcile %q: API returned a value but field was not set in config and is not computed",
+			field,
+		)
+	default:
+		return null, nil
+	}
+}

--- a/internal/provider/reconcile_test.go
+++ b/internal/provider/reconcile_test.go
@@ -1,0 +1,341 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// --- reconcileString ---
+
+func TestReconcileString_BothNonEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringValue("plan"), types.StringValue("api"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueString() != "api" {
+		t.Fatalf("expected output value 'api', got %q", got.ValueString())
+	}
+}
+
+func TestReconcileString_InputNonEmpty_OutputNull(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringValue("secret"), types.StringNull(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueString() != "secret" {
+		t.Fatalf("expected echoed input 'secret', got %q", got.ValueString())
+	}
+}
+
+func TestReconcileString_InputNonEmpty_OutputEmptyString(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringValue("secret"), types.StringValue(""), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueString() != "secret" {
+		t.Fatalf("expected echoed input 'secret', got %q", got.ValueString())
+	}
+}
+
+func TestReconcileString_InputNull_OutputNonEmpty_Computed(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringNull(), types.StringValue("server-id"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueString() != "server-id" {
+		t.Fatalf("expected output value 'server-id', got %q", got.ValueString())
+	}
+}
+
+func TestReconcileString_InputNull_OutputNonEmpty_NotComputed(t *testing.T) {
+	t.Parallel()
+	_, err := reconcileString("my_field", types.StringNull(), types.StringValue("surprise"), false)
+	if err == nil {
+		t.Fatal("expected error for unexpected API value on non-computed field")
+	}
+}
+
+func TestReconcileString_InputEmpty_OutputNonEmpty_NotComputed(t *testing.T) {
+	t.Parallel()
+	_, err := reconcileString("my_field", types.StringValue(""), types.StringValue("surprise"), false)
+	if err == nil {
+		t.Fatal("expected error for unexpected API value on non-computed field (empty string input)")
+	}
+}
+
+func TestReconcileString_BothNull(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringNull(), types.StringNull(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsNull() {
+		t.Fatalf("expected null, got %q", got.ValueString())
+	}
+}
+
+func TestReconcileString_BothEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringValue(""), types.StringValue(""), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsNull() {
+		t.Fatalf("expected null, got %q", got.ValueString())
+	}
+}
+
+func TestReconcileString_InputUnknown_OutputNonEmpty_Computed(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileString("f", types.StringUnknown(), types.StringValue("resolved"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueString() != "resolved" {
+		t.Fatalf("expected 'resolved', got %q", got.ValueString())
+	}
+}
+
+// --- reconcileBool ---
+
+func TestReconcileBool_BothNonEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileBool("f", types.BoolValue(true), types.BoolValue(false), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueBool() != false {
+		t.Fatal("expected output value false")
+	}
+}
+
+func TestReconcileBool_InputNonEmpty_OutputNull(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileBool("f", types.BoolValue(true), types.BoolNull(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueBool() != true {
+		t.Fatal("expected echoed input true")
+	}
+}
+
+func TestReconcileBool_InputNull_OutputNonEmpty_Computed(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileBool("f", types.BoolNull(), types.BoolValue(true), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueBool() != true {
+		t.Fatal("expected output value true")
+	}
+}
+
+func TestReconcileBool_InputNull_OutputNonEmpty_NotComputed(t *testing.T) {
+	t.Parallel()
+	_, err := reconcileBool("my_field", types.BoolNull(), types.BoolValue(true), false)
+	if err == nil {
+		t.Fatal("expected error for unexpected API value on non-computed field")
+	}
+}
+
+func TestReconcileBool_BothNull(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileBool("f", types.BoolNull(), types.BoolNull(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsNull() {
+		t.Fatal("expected null")
+	}
+}
+
+func TestReconcileBool_FalseIsNotEmpty(t *testing.T) {
+	t.Parallel()
+	// false is a valid value, not "empty"
+	got, err := reconcileBool("f", types.BoolValue(false), types.BoolNull(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueBool() != false {
+		t.Fatal("expected echoed input false")
+	}
+	if got.IsNull() {
+		t.Fatal("false should not be treated as empty")
+	}
+}
+
+// --- reconcileInt64 ---
+
+func TestReconcileInt64_BothNonEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileInt64("f", types.Int64Value(10), types.Int64Value(20), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueInt64() != 20 {
+		t.Fatalf("expected output value 20, got %d", got.ValueInt64())
+	}
+}
+
+func TestReconcileInt64_InputNonEmpty_OutputNull(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileInt64("f", types.Int64Value(42), types.Int64Null(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueInt64() != 42 {
+		t.Fatalf("expected echoed input 42, got %d", got.ValueInt64())
+	}
+}
+
+func TestReconcileInt64_InputNull_OutputNonEmpty_Computed(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileInt64("f", types.Int64Null(), types.Int64Value(99), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueInt64() != 99 {
+		t.Fatalf("expected output value 99, got %d", got.ValueInt64())
+	}
+}
+
+func TestReconcileInt64_InputNull_OutputNonEmpty_NotComputed(t *testing.T) {
+	t.Parallel()
+	_, err := reconcileInt64("my_field", types.Int64Null(), types.Int64Value(99), false)
+	if err == nil {
+		t.Fatal("expected error for unexpected API value on non-computed field")
+	}
+}
+
+func TestReconcileInt64_BothNull(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileInt64("f", types.Int64Null(), types.Int64Null(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.IsNull() {
+		t.Fatal("expected null")
+	}
+}
+
+func TestReconcileInt64_ZeroIsNotEmpty(t *testing.T) {
+	t.Parallel()
+	// 0 is a valid value, not "empty"
+	got, err := reconcileInt64("f", types.Int64Value(0), types.Int64Null(), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ValueInt64() != 0 {
+		t.Fatalf("expected echoed input 0, got %d", got.ValueInt64())
+	}
+	if got.IsNull() {
+		t.Fatal("0 should not be treated as empty")
+	}
+}
+
+// --- reconcileSlice ---
+
+func TestReconcileSlice_BothNonEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileSlice("f", []string{"a"}, []string{"b"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "b" {
+		t.Fatalf("expected output [b], got %v", got)
+	}
+}
+
+func TestReconcileSlice_InputNonEmpty_OutputEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileSlice("f", []string{"a"}, []string(nil), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "a" {
+		t.Fatalf("expected echoed input [a], got %v", got)
+	}
+}
+
+func TestReconcileSlice_InputEmpty_OutputNonEmpty_Computed(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileSlice("f", []string(nil), []string{"x"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "x" {
+		t.Fatalf("expected output [x], got %v", got)
+	}
+}
+
+func TestReconcileSlice_InputEmpty_OutputNonEmpty_NotComputed(t *testing.T) {
+	t.Parallel()
+	_, err := reconcileSlice("my_field", []string(nil), []string{"x"}, false)
+	if err == nil {
+		t.Fatal("expected error for unexpected API value on non-computed field")
+	}
+}
+
+func TestReconcileSlice_BothEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileSlice("f", []string(nil), []string(nil), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+// --- reconcileMapSet ---
+
+func TestReconcileMapSet_BothNonEmpty(t *testing.T) {
+	t.Parallel()
+	input := map[string]types.Set{"a": types.SetNull(types.StringType)}
+	output := map[string]types.Set{"b": types.SetNull(types.StringType)}
+	got, err := reconcileMapSet("f", input, output, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["b"]; !ok {
+		t.Fatal("expected output map with key 'b'")
+	}
+}
+
+func TestReconcileMapSet_InputNonEmpty_OutputEmpty(t *testing.T) {
+	t.Parallel()
+	input := map[string]types.Set{"a": types.SetNull(types.StringType)}
+	got, err := reconcileMapSet("f", input, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := got["a"]; !ok {
+		t.Fatal("expected echoed input map with key 'a'")
+	}
+}
+
+func TestReconcileMapSet_InputEmpty_OutputNonEmpty_NotComputed(t *testing.T) {
+	t.Parallel()
+	output := map[string]types.Set{"b": types.SetNull(types.StringType)}
+	_, err := reconcileMapSet("my_field", nil, output, false)
+	if err == nil {
+		t.Fatal("expected error for unexpected API value on non-computed field")
+	}
+}
+
+func TestReconcileMapSet_BothEmpty(t *testing.T) {
+	t.Parallel()
+	got, err := reconcileMapSet("f", nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatal("expected nil")
+	}
+}

--- a/internal/provider/reconcile_test.go
+++ b/internal/provider/reconcile_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -58,6 +59,10 @@ func TestReconcileString_InputNull_OutputNonEmpty_NotComputed(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unexpected API value on non-computed field")
 	}
+	// The API value may be a secret; the error must never contain it.
+	if strings.Contains(err.Error(), "surprise") {
+		t.Fatalf("error must not leak the raw API value, got %q", err.Error())
+	}
 }
 
 func TestReconcileString_InputEmpty_OutputNonEmpty_NotComputed(t *testing.T) {
@@ -65,6 +70,10 @@ func TestReconcileString_InputEmpty_OutputNonEmpty_NotComputed(t *testing.T) {
 	_, err := reconcileString("my_field", types.StringValue(""), types.StringValue("surprise"), false)
 	if err == nil {
 		t.Fatal("expected error for unexpected API value on non-computed field (empty string input)")
+	}
+	// The API value may be a secret; the error must never contain it.
+	if strings.Contains(err.Error(), "surprise") {
+		t.Fatalf("error must not leak the raw API value, got %q", err.Error())
 	}
 }
 

--- a/internal/provider/reconcile_test.go
+++ b/internal/provider/reconcile_test.go
@@ -1,0 +1,202 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// reconcileCase is one row of the four-way matrix for a scalar kind. want is
+// ignored when wantErr is set: an error always yields the null value.
+type reconcileCase[V scalarValue] struct {
+	name     string
+	input    V
+	output   V
+	computed bool
+	want     V
+	wantErr  bool
+}
+
+func runReconcileCases[V scalarValue](t *testing.T, cases []reconcileCase[V]) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := reconcileValue("my_field", tc.input, tc.output, tc.computed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error for unexpected API value on non-computed field")
+				}
+				if !got.IsNull() {
+					t.Fatalf("expected null alongside the error, got %s", got)
+				}
+				// The API value may be a secret; the error must never contain it.
+				if leaked := strings.Trim(tc.output.String(), `"`); strings.Contains(err.Error(), leaked) {
+					t.Fatalf("error must not leak the raw API value %q, got %q", leaked, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !got.Equal(tc.want) {
+				t.Fatalf("expected %s, got %s", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestReconcileValue_String(t *testing.T) {
+	t.Parallel()
+	runReconcileCases(t, []reconcileCase[types.String]{
+		{name: "both non-empty: output wins", input: types.StringValue("plan"), output: types.StringValue("api"), want: types.StringValue("api")},
+		{name: "input non-empty, output null: echo input", input: types.StringValue("secret"), output: types.StringNull(), want: types.StringValue("secret")},
+		{name: "input non-empty, output empty string: echo input", input: types.StringValue("secret"), output: types.StringValue(""), want: types.StringValue("secret")},
+		{name: "input null, output non-empty, computed: output", input: types.StringNull(), output: types.StringValue("server-id"), computed: true, want: types.StringValue("server-id")},
+		{name: "input unknown, output non-empty, computed: output", input: types.StringUnknown(), output: types.StringValue("resolved"), computed: true, want: types.StringValue("resolved")},
+		{name: "input null, output non-empty, not computed: error", input: types.StringNull(), output: types.StringValue("surprise"), wantErr: true},
+		{name: "input empty string, output non-empty, not computed: error", input: types.StringValue(""), output: types.StringValue("surprise"), wantErr: true},
+		{name: "both null: null", input: types.StringNull(), output: types.StringNull(), want: types.StringNull()},
+		{name: "both empty string: null", input: types.StringValue(""), output: types.StringValue(""), want: types.StringNull()},
+	})
+}
+
+func TestReconcileValue_Bool(t *testing.T) {
+	t.Parallel()
+	runReconcileCases(t, []reconcileCase[types.Bool]{
+		{name: "both non-empty: output wins", input: types.BoolValue(true), output: types.BoolValue(false), want: types.BoolValue(false)},
+		{name: "input non-empty, output null: echo input", input: types.BoolValue(true), output: types.BoolNull(), want: types.BoolValue(true)},
+		{name: "false is a value, not empty", input: types.BoolValue(false), output: types.BoolNull(), want: types.BoolValue(false)},
+		{name: "input null, output non-empty, computed: output", input: types.BoolNull(), output: types.BoolValue(true), computed: true, want: types.BoolValue(true)},
+		{name: "input null, output non-empty, not computed: error", input: types.BoolNull(), output: types.BoolValue(true), wantErr: true},
+		{name: "both null: null", input: types.BoolNull(), output: types.BoolNull(), want: types.BoolNull()},
+	})
+}
+
+func TestReconcileValue_Int64(t *testing.T) {
+	t.Parallel()
+	runReconcileCases(t, []reconcileCase[types.Int64]{
+		{name: "both non-empty: output wins", input: types.Int64Value(10), output: types.Int64Value(20), want: types.Int64Value(20)},
+		{name: "input non-empty, output null: echo input", input: types.Int64Value(42), output: types.Int64Null(), want: types.Int64Value(42)},
+		{name: "zero is a value, not empty", input: types.Int64Value(0), output: types.Int64Null(), want: types.Int64Value(0)},
+		{name: "input null, output non-empty, computed: output", input: types.Int64Null(), output: types.Int64Value(99), computed: true, want: types.Int64Value(99)},
+		{name: "input null, output non-empty, not computed: error", input: types.Int64Null(), output: types.Int64Value(99), wantErr: true},
+		{name: "both null: null", input: types.Int64Null(), output: types.Int64Null(), want: types.Int64Null()},
+	})
+}
+
+func TestReconcileSlice(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		input    []string
+		output   []string
+		computed bool
+		want     []string
+		wantErr  bool
+	}{
+		{name: "both non-empty: output wins", input: []string{"a"}, output: []string{"b"}, want: []string{"b"}},
+		{name: "input non-empty, output empty: echo input", input: []string{"a"}, output: nil, want: []string{"a"}},
+		{name: "input empty, output non-empty, computed: output", input: nil, output: []string{"x"}, computed: true, want: []string{"x"}},
+		{name: "input empty, output non-empty, not computed: error", input: nil, output: []string{"x"}, wantErr: true},
+		{name: "both empty: nil", input: nil, output: nil, want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := reconcileSlice("my_field", tc.input, tc.output, tc.computed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error for unexpected API value on non-computed field")
+				}
+				if got != nil {
+					t.Fatalf("expected nil alongside the error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("expected %v, got %v", tc.want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileMapSet(t *testing.T) {
+	t.Parallel()
+	a := map[string]types.Set{"a": types.SetNull(types.StringType)}
+	b := map[string]types.Set{"b": types.SetNull(types.StringType)}
+	cases := []struct {
+		name     string
+		input    map[string]types.Set
+		output   map[string]types.Set
+		computed bool
+		wantKey  string // "" means a nil result is expected
+		wantErr  bool
+	}{
+		{name: "both non-empty: output wins", input: a, output: b, wantKey: "b"},
+		{name: "input non-empty, output empty: echo input", input: a, output: nil, wantKey: "a"},
+		{name: "input empty, output non-empty, computed: output", input: nil, output: b, computed: true, wantKey: "b"},
+		{name: "input empty, output non-empty, not computed: error", input: nil, output: b, wantErr: true},
+		{name: "both empty: nil", input: nil, output: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := reconcileMapSet("my_field", tc.input, tc.output, tc.computed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error for unexpected API value on non-computed field")
+				}
+				if got != nil {
+					t.Fatalf("expected nil alongside the error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.wantKey == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if _, ok := got[tc.wantKey]; !ok || len(got) != 1 {
+				t.Fatalf("expected a map with only key %q, got %v", tc.wantKey, got)
+			}
+		})
+	}
+}
+
+// TestPlanTarget covers the import path (typed nil) and a type mismatch: both
+// must yield a usable zero-value target whose fields reconcile as empty.
+func TestPlanTarget(t *testing.T) {
+	t.Parallel()
+
+	set := &AblyRuleTargetHTTP{Url: types.StringValue("https://example.com")}
+	if got := planTarget[AblyRuleTargetHTTP](set); got != set {
+		t.Fatal("expected the plan target to be returned as-is")
+	}
+
+	var typedNil *AblyRuleTargetHTTP
+	if got := planTarget[AblyRuleTargetHTTP](typedNil); got == nil || !got.Url.IsNull() {
+		t.Fatalf("expected a zero-value target for a typed nil, got %v", got)
+	}
+
+	if got := planTarget[AblyRuleTargetHTTP](&AblyRuleTargetZapier{}); got == nil || !got.Url.IsNull() {
+		t.Fatalf("expected a zero-value target for a type mismatch, got %v", got)
+	}
+
+	if got := planTarget[AblyRuleTargetHTTP](nil); got == nil || got.Headers != nil {
+		t.Fatalf("expected a zero-value target for a nil interface, got %v", got)
+	}
+}

--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -93,7 +93,7 @@ func (r ResourceApp) Schema(ctx context.Context, req resource.SchemaRequest, res
 				Description: "Enforce TLS for all connections. This setting overrides any channel setting.",
 				Computed:    true,
 				PlanModifiers: []planmodifier.Bool{
-					DefaultBoolAttribute(types.BoolValue(false)),
+					DefaultBoolAttribute(types.BoolValue(true)),
 				},
 			},
 			"fcm_key": schema.StringAttribute{
@@ -189,6 +189,34 @@ func (r ResourceApp) Metadata(ctx context.Context, req resource.MetadataRequest,
 	resp.TypeName = "ably_app"
 }
 
+// buildAppState reconciles plan/state input with an API response into an AblyAppState.
+// For Create/Update, pass the plan as input. For Read, pass the prior state.
+func buildAppState(rc *reconciler, input AblyAppState, api control.AppResponse) AblyAppState {
+	return AblyAppState{
+		AccountID:                   rc.str("account_id", input.AccountID, types.StringValue(api.AccountID), true),
+		ID:                          rc.str("id", input.ID, types.StringValue(api.ID), true),
+		Name:                        rc.str("name", input.Name, types.StringValue(api.Name), false),
+		Status:                      rc.str("status", input.Status, types.StringValue(api.Status), true),
+		TLSOnly:                     rc.boolean("tls_only", input.TLSOnly, optBoolValue(api.TLSOnly), true),
+		FcmKey:                      rc.str("fcm_key", input.FcmKey, types.StringNull(), false),
+		FcmServiceAccount:           rc.str("fcm_service_account", input.FcmServiceAccount, types.StringNull(), false),
+		FcmProjectId:                rc.str("fcm_project_id", input.FcmProjectId, optStringValue(api.FCMProjectID), false),
+		FcmServiceAccountConfigured: rc.boolean("fcm_service_account_configured", input.FcmServiceAccountConfigured, optBoolValue(api.FCMServiceAccountConfigured), true),
+		ApnsCertificate:             rc.str("apns_certificate", input.ApnsCertificate, types.StringNull(), false),
+		ApnsPrivateKey:              rc.str("apns_private_key", input.ApnsPrivateKey, types.StringNull(), false),
+		ApnsUseSandboxEndpoint:      rc.boolean("apns_use_sandbox_endpoint", input.ApnsUseSandboxEndpoint, optBoolValue(api.APNSUseSandboxEndpoint), true),
+		ApnsAuthType:                rc.str("apns_auth_type", input.ApnsAuthType, optStringValue(api.APNSAuthType), true),
+		ApnsSigningKey:              rc.str("apns_signing_key", input.ApnsSigningKey, types.StringNull(), false),
+		ApnsSigningKeyId:            rc.str("apns_signing_key_id", input.ApnsSigningKeyId, optStringValue(api.APNSSigningKeyID), true),
+		ApnsIssuerKey:               rc.str("apns_issuer_key", input.ApnsIssuerKey, optStringValue(api.APNSIssuerKey), true),
+		ApnsTopicHeader:             rc.str("apns_topic_header", input.ApnsTopicHeader, optStringValue(api.APNSTopicHeader), true),
+		ApnsCertificateConfigured:   rc.boolean("apns_certificate_configured", input.ApnsCertificateConfigured, optBoolValue(api.APNSCertificateConfigured), true),
+		ApnsSigningKeyConfigured:    rc.boolean("apns_signing_key_configured", input.ApnsSigningKeyConfigured, optBoolValue(api.APNSSigningKeyConfigured), true),
+		Created:                     rc.str("created", input.Created, types.StringValue(formatTimestamp(api.Created)), true),
+		Modified:                    rc.str("modified", input.Modified, types.StringValue(formatTimestamp(api.Modified)), true),
+	}
+}
+
 // Create creates a new resource.
 func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -259,33 +287,11 @@ func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyAppState{
-		AccountID:                   types.StringValue(ablyApp.AccountID),
-		ID:                          types.StringValue(ablyApp.ID),
-		Name:                        types.StringValue(ablyApp.Name),
-		Status:                      types.StringValue(ablyApp.Status),
-		TLSOnly:                     types.BoolValue(deref(ablyApp.TLSOnly)),
-		FcmKey:                      plan.FcmKey,
-		FcmServiceAccount:           plan.FcmServiceAccount,
-		FcmProjectId:                optStringValue(ablyApp.FCMProjectID),
-		FcmServiceAccountConfigured: types.BoolValue(deref(ablyApp.FCMServiceAccountConfigured)),
-		ApnsCertificate:             plan.ApnsCertificate,
-		ApnsPrivateKey:              plan.ApnsPrivateKey,
-		ApnsUseSandboxEndpoint:      types.BoolValue(deref(ablyApp.APNSUseSandboxEndpoint)),
-		ApnsAuthType:                optStringValue(ablyApp.APNSAuthType),
-		ApnsSigningKey:              plan.ApnsSigningKey,
-		ApnsSigningKeyId:            optStringValue(ablyApp.APNSSigningKeyID),
-		ApnsIssuerKey:               optStringValue(ablyApp.APNSIssuerKey),
-		ApnsTopicHeader:             optStringValue(ablyApp.APNSTopicHeader),
-		ApnsCertificateConfigured:   types.BoolValue(deref(ablyApp.APNSCertificateConfigured)),
-		ApnsSigningKeyConfigured:    types.BoolValue(deref(ablyApp.APNSSigningKeyConfigured)),
-		Created:                     types.StringValue(formatTimestamp(ablyApp.Created)),
-		Modified:                    types.StringValue(formatTimestamp(ablyApp.Modified)),
+	rc := newReconciler(&resp.Diagnostics)
+	respApps := buildAppState(rc, plan, ablyApp)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	emptyStringToNull(&respApps.FcmKey)
-	emptyStringToNull(&respApps.ApnsCertificate)
-	emptyStringToNull(&respApps.ApnsPrivateKey)
-	emptyStringToNull(&respApps.ApnsSigningKey)
 
 	// Sets state for the new Ably App.
 	diags = resp.State.Set(ctx, respApps)
@@ -328,33 +334,11 @@ func (r ResourceApp) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	// Loops through apps and if account id matches, sets state.
 	for _, v := range apps {
 		if v.ID == appID {
-			respApps := AblyAppState{
-				AccountID:                   types.StringValue(v.AccountID),
-				ID:                          types.StringValue(v.ID),
-				Name:                        types.StringValue(v.Name),
-				Status:                      types.StringValue(v.Status),
-				TLSOnly:                     types.BoolValue(deref(v.TLSOnly)),
-				FcmKey:                      state.FcmKey,
-				FcmServiceAccount:           state.FcmServiceAccount,
-				FcmProjectId:                optStringValue(v.FCMProjectID),
-				FcmServiceAccountConfigured: types.BoolValue(deref(v.FCMServiceAccountConfigured)),
-				ApnsCertificate:             state.ApnsCertificate,
-				ApnsPrivateKey:              state.ApnsPrivateKey,
-				ApnsUseSandboxEndpoint:      types.BoolValue(deref(v.APNSUseSandboxEndpoint)),
-				ApnsAuthType:                optStringValue(v.APNSAuthType),
-				ApnsSigningKey:              state.ApnsSigningKey,
-				ApnsSigningKeyId:            optStringValue(v.APNSSigningKeyID),
-				ApnsIssuerKey:               optStringValue(v.APNSIssuerKey),
-				ApnsTopicHeader:             optStringValue(v.APNSTopicHeader),
-				ApnsCertificateConfigured:   types.BoolValue(deref(v.APNSCertificateConfigured)),
-				ApnsSigningKeyConfigured:    types.BoolValue(deref(v.APNSSigningKeyConfigured)),
-				Created:                     types.StringValue(formatTimestamp(v.Created)),
-				Modified:                    types.StringValue(formatTimestamp(v.Modified)),
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respApps := buildAppState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
-			emptyStringToNull(&respApps.FcmKey)
-			emptyStringToNull(&respApps.ApnsCertificate)
-			emptyStringToNull(&respApps.ApnsPrivateKey)
-			emptyStringToNull(&respApps.ApnsSigningKey)
 			found = true
 
 			// Sets state to app values.
@@ -453,33 +437,11 @@ func (r ResourceApp) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	respApps := AblyAppState{
-		ID:                          types.StringValue(ablyApp.ID),
-		AccountID:                   types.StringValue(ablyApp.AccountID),
-		Name:                        types.StringValue(ablyApp.Name),
-		Status:                      types.StringValue(ablyApp.Status),
-		TLSOnly:                     types.BoolValue(deref(ablyApp.TLSOnly)),
-		FcmKey:                      plan.FcmKey,
-		FcmServiceAccount:           plan.FcmServiceAccount,
-		FcmProjectId:                optStringValue(ablyApp.FCMProjectID),
-		FcmServiceAccountConfigured: types.BoolValue(deref(ablyApp.FCMServiceAccountConfigured)),
-		ApnsCertificate:             plan.ApnsCertificate,
-		ApnsPrivateKey:              plan.ApnsPrivateKey,
-		ApnsUseSandboxEndpoint:      types.BoolValue(deref(ablyApp.APNSUseSandboxEndpoint)),
-		ApnsAuthType:                optStringValue(ablyApp.APNSAuthType),
-		ApnsSigningKey:              plan.ApnsSigningKey,
-		ApnsSigningKeyId:            optStringValue(ablyApp.APNSSigningKeyID),
-		ApnsIssuerKey:               optStringValue(ablyApp.APNSIssuerKey),
-		ApnsTopicHeader:             optStringValue(ablyApp.APNSTopicHeader),
-		ApnsCertificateConfigured:   types.BoolValue(deref(ablyApp.APNSCertificateConfigured)),
-		ApnsSigningKeyConfigured:    types.BoolValue(deref(ablyApp.APNSSigningKeyConfigured)),
-		Created:                     types.StringValue(formatTimestamp(ablyApp.Created)),
-		Modified:                    types.StringValue(formatTimestamp(ablyApp.Modified)),
+	rc := newReconciler(&resp.Diagnostics)
+	respApps := buildAppState(rc, plan, ablyApp)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	emptyStringToNull(&respApps.FcmKey)
-	emptyStringToNull(&respApps.ApnsCertificate)
-	emptyStringToNull(&respApps.ApnsPrivateKey)
-	emptyStringToNull(&respApps.ApnsSigningKey)
 
 	// Sets state to new app.
 	diags = resp.State.Set(ctx, respApps)

--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -90,10 +91,14 @@ func (r ResourceApp) Schema(ctx context.Context, req resource.SchemaRequest, res
 			},
 			"tls_only": schema.BoolAttribute{
 				Optional:    true,
-				Description: "Enforce TLS for all connections. This setting overrides any channel setting.",
+				Description: "Enforce TLS for all connections. This setting overrides any channel setting. When unset, the Control API's default applies.",
 				Computed:    true,
+				// No client-side default: the vendored spec defines none for
+				// app-level tlsOnly, so when unset the field is omitted from
+				// the request and the server's choice is recorded. Prior state
+				// is kept on update so the value round-trips unchanged.
 				PlanModifiers: []planmodifier.Bool{
-					DefaultBoolAttribute(types.BoolValue(false)),
+					boolplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"fcm_key": schema.StringAttribute{

--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -194,6 +194,34 @@ func (r ResourceApp) Metadata(ctx context.Context, req resource.MetadataRequest,
 	resp.TypeName = "ably_app"
 }
 
+// buildAppState reconciles plan/state input with an API response into an AblyAppState.
+// For Create/Update, pass the plan as input. For Read, pass the prior state.
+func buildAppState(rc *reconciler, input AblyAppState, api control.AppResponse) AblyAppState {
+	return AblyAppState{
+		AccountID:                   rcVal(rc, "account_id", input.AccountID, types.StringValue(api.AccountID), true),
+		ID:                          rcVal(rc, "id", input.ID, types.StringValue(api.ID), true),
+		Name:                        rcVal(rc, "name", input.Name, types.StringValue(api.Name), false),
+		Status:                      rcVal(rc, "status", input.Status, types.StringValue(api.Status), true),
+		TLSOnly:                     rcVal(rc, "tls_only", input.TLSOnly, optBoolValue(api.TLSOnly), true),
+		FcmKey:                      rcVal(rc, "fcm_key", input.FcmKey, types.StringNull(), false),
+		FcmServiceAccount:           rcVal(rc, "fcm_service_account", input.FcmServiceAccount, types.StringNull(), false),
+		FcmProjectId:                rcVal(rc, "fcm_project_id", input.FcmProjectId, optStringValue(api.FCMProjectID), false),
+		FcmServiceAccountConfigured: rcVal(rc, "fcm_service_account_configured", input.FcmServiceAccountConfigured, optBoolValue(api.FCMServiceAccountConfigured), true),
+		ApnsCertificate:             rcVal(rc, "apns_certificate", input.ApnsCertificate, types.StringNull(), false),
+		ApnsPrivateKey:              rcVal(rc, "apns_private_key", input.ApnsPrivateKey, types.StringNull(), false),
+		ApnsUseSandboxEndpoint:      rcVal(rc, "apns_use_sandbox_endpoint", input.ApnsUseSandboxEndpoint, optBoolValue(api.APNSUseSandboxEndpoint), true),
+		ApnsAuthType:                rcVal(rc, "apns_auth_type", input.ApnsAuthType, optStringValue(api.APNSAuthType), true),
+		ApnsSigningKey:              rcVal(rc, "apns_signing_key", input.ApnsSigningKey, types.StringNull(), false),
+		ApnsSigningKeyId:            rcVal(rc, "apns_signing_key_id", input.ApnsSigningKeyId, optStringValue(api.APNSSigningKeyID), true),
+		ApnsIssuerKey:               rcVal(rc, "apns_issuer_key", input.ApnsIssuerKey, optStringValue(api.APNSIssuerKey), true),
+		ApnsTopicHeader:             rcVal(rc, "apns_topic_header", input.ApnsTopicHeader, optStringValue(api.APNSTopicHeader), true),
+		ApnsCertificateConfigured:   rcVal(rc, "apns_certificate_configured", input.ApnsCertificateConfigured, optBoolValue(api.APNSCertificateConfigured), true),
+		ApnsSigningKeyConfigured:    rcVal(rc, "apns_signing_key_configured", input.ApnsSigningKeyConfigured, optBoolValue(api.APNSSigningKeyConfigured), true),
+		Created:                     rcVal(rc, "created", input.Created, types.StringValue(formatTimestamp(api.Created)), true),
+		Modified:                    rcVal(rc, "modified", input.Modified, types.StringValue(formatTimestamp(api.Modified)), true),
+	}
+}
+
 // Create creates a new resource.
 func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -235,6 +263,7 @@ func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, res
 		)
 		return
 	}
+	recordCreatedIdentity(ctx, resp, map[string]string{"id": ablyApp.ID})
 
 	// Read back the resource via GET to ensure computed fields like `modified`
 	// reflect the settled server state (the POST response may return a value
@@ -264,33 +293,11 @@ func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyAppState{
-		AccountID:                   types.StringValue(ablyApp.AccountID),
-		ID:                          types.StringValue(ablyApp.ID),
-		Name:                        types.StringValue(ablyApp.Name),
-		Status:                      types.StringValue(ablyApp.Status),
-		TLSOnly:                     types.BoolValue(deref(ablyApp.TLSOnly)),
-		FcmKey:                      plan.FcmKey,
-		FcmServiceAccount:           plan.FcmServiceAccount,
-		FcmProjectId:                optStringValue(ablyApp.FCMProjectID),
-		FcmServiceAccountConfigured: types.BoolValue(deref(ablyApp.FCMServiceAccountConfigured)),
-		ApnsCertificate:             plan.ApnsCertificate,
-		ApnsPrivateKey:              plan.ApnsPrivateKey,
-		ApnsUseSandboxEndpoint:      types.BoolValue(deref(ablyApp.APNSUseSandboxEndpoint)),
-		ApnsAuthType:                optStringValue(ablyApp.APNSAuthType),
-		ApnsSigningKey:              plan.ApnsSigningKey,
-		ApnsSigningKeyId:            optStringValue(ablyApp.APNSSigningKeyID),
-		ApnsIssuerKey:               optStringValue(ablyApp.APNSIssuerKey),
-		ApnsTopicHeader:             optStringValue(ablyApp.APNSTopicHeader),
-		ApnsCertificateConfigured:   types.BoolValue(deref(ablyApp.APNSCertificateConfigured)),
-		ApnsSigningKeyConfigured:    types.BoolValue(deref(ablyApp.APNSSigningKeyConfigured)),
-		Created:                     types.StringValue(formatTimestamp(ablyApp.Created)),
-		Modified:                    types.StringValue(formatTimestamp(ablyApp.Modified)),
+	rc := newReconciler(&resp.Diagnostics)
+	respApps := buildAppState(rc, plan, ablyApp)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	emptyStringToNull(&respApps.FcmKey)
-	emptyStringToNull(&respApps.ApnsCertificate)
-	emptyStringToNull(&respApps.ApnsPrivateKey)
-	emptyStringToNull(&respApps.ApnsSigningKey)
 
 	// Sets state for the new Ably App.
 	diags = resp.State.Set(ctx, respApps)
@@ -333,33 +340,11 @@ func (r ResourceApp) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	// Loops through apps and if account id matches, sets state.
 	for _, v := range apps {
 		if v.ID == appID {
-			respApps := AblyAppState{
-				AccountID:                   types.StringValue(v.AccountID),
-				ID:                          types.StringValue(v.ID),
-				Name:                        types.StringValue(v.Name),
-				Status:                      types.StringValue(v.Status),
-				TLSOnly:                     types.BoolValue(deref(v.TLSOnly)),
-				FcmKey:                      state.FcmKey,
-				FcmServiceAccount:           state.FcmServiceAccount,
-				FcmProjectId:                optStringValue(v.FCMProjectID),
-				FcmServiceAccountConfigured: types.BoolValue(deref(v.FCMServiceAccountConfigured)),
-				ApnsCertificate:             state.ApnsCertificate,
-				ApnsPrivateKey:              state.ApnsPrivateKey,
-				ApnsUseSandboxEndpoint:      types.BoolValue(deref(v.APNSUseSandboxEndpoint)),
-				ApnsAuthType:                optStringValue(v.APNSAuthType),
-				ApnsSigningKey:              state.ApnsSigningKey,
-				ApnsSigningKeyId:            optStringValue(v.APNSSigningKeyID),
-				ApnsIssuerKey:               optStringValue(v.APNSIssuerKey),
-				ApnsTopicHeader:             optStringValue(v.APNSTopicHeader),
-				ApnsCertificateConfigured:   types.BoolValue(deref(v.APNSCertificateConfigured)),
-				ApnsSigningKeyConfigured:    types.BoolValue(deref(v.APNSSigningKeyConfigured)),
-				Created:                     types.StringValue(formatTimestamp(v.Created)),
-				Modified:                    types.StringValue(formatTimestamp(v.Modified)),
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respApps := buildAppState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
-			emptyStringToNull(&respApps.FcmKey)
-			emptyStringToNull(&respApps.ApnsCertificate)
-			emptyStringToNull(&respApps.ApnsPrivateKey)
-			emptyStringToNull(&respApps.ApnsSigningKey)
 			found = true
 
 			// Sets state to app values.
@@ -458,33 +443,11 @@ func (r ResourceApp) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	respApps := AblyAppState{
-		ID:                          types.StringValue(ablyApp.ID),
-		AccountID:                   types.StringValue(ablyApp.AccountID),
-		Name:                        types.StringValue(ablyApp.Name),
-		Status:                      types.StringValue(ablyApp.Status),
-		TLSOnly:                     types.BoolValue(deref(ablyApp.TLSOnly)),
-		FcmKey:                      plan.FcmKey,
-		FcmServiceAccount:           plan.FcmServiceAccount,
-		FcmProjectId:                optStringValue(ablyApp.FCMProjectID),
-		FcmServiceAccountConfigured: types.BoolValue(deref(ablyApp.FCMServiceAccountConfigured)),
-		ApnsCertificate:             plan.ApnsCertificate,
-		ApnsPrivateKey:              plan.ApnsPrivateKey,
-		ApnsUseSandboxEndpoint:      types.BoolValue(deref(ablyApp.APNSUseSandboxEndpoint)),
-		ApnsAuthType:                optStringValue(ablyApp.APNSAuthType),
-		ApnsSigningKey:              plan.ApnsSigningKey,
-		ApnsSigningKeyId:            optStringValue(ablyApp.APNSSigningKeyID),
-		ApnsIssuerKey:               optStringValue(ablyApp.APNSIssuerKey),
-		ApnsTopicHeader:             optStringValue(ablyApp.APNSTopicHeader),
-		ApnsCertificateConfigured:   types.BoolValue(deref(ablyApp.APNSCertificateConfigured)),
-		ApnsSigningKeyConfigured:    types.BoolValue(deref(ablyApp.APNSSigningKeyConfigured)),
-		Created:                     types.StringValue(formatTimestamp(ablyApp.Created)),
-		Modified:                    types.StringValue(formatTimestamp(ablyApp.Modified)),
+	rc := newReconciler(&resp.Diagnostics)
+	respApps := buildAppState(rc, plan, ablyApp)
+	if resp.Diagnostics.HasError() {
+		return
 	}
-	emptyStringToNull(&respApps.FcmKey)
-	emptyStringToNull(&respApps.ApnsCertificate)
-	emptyStringToNull(&respApps.ApnsPrivateKey)
-	emptyStringToNull(&respApps.ApnsSigningKey)
 
 	// Sets state to new app.
 	diags = resp.State.Set(ctx, respApps)

--- a/internal/provider/resource_ably_app_test.go
+++ b/internal/provider/resource_ably_app_test.go
@@ -230,3 +230,45 @@ resource "ably_app" "app0" {
 		},
 	})
 }
+
+func TestAccAblyApp_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ably_app.app0", "name", appName),
+					// Computed-only fields are populated
+					resource.TestCheckResourceAttrSet("ably_app.app0", "id"),
+					resource.TestCheckResourceAttrSet("ably_app.app0", "account_id"),
+					resource.TestCheckResourceAttrSet("ably_app.app0", "created"),
+					resource.TestCheckResourceAttrSet("ably_app.app0", "modified"),
+					// Optional+Computed defaults
+					resource.TestCheckResourceAttr("ably_app.app0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_app.app0", "tls_only", "true"),
+					resource.TestCheckResourceAttr("ably_app.app0", "apns_use_sandbox_endpoint", "false"),
+					// Optional-only fields should not be in state
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_key"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_service_account"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_project_id"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "apns_certificate"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "apns_private_key"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "apns_signing_key"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_ably_app_test.go
+++ b/internal/provider/resource_ably_app_test.go
@@ -274,3 +274,50 @@ resource "ably_app" "app0" {
 		},
 	})
 }
+
+// TestAccAblyApp_LegacyEmptyFCMProjectID reproduces INF-8172. The Control API
+// returns "fcmProjectId": "" for apps that were created or patched by the
+// pre-1.0 provider, whose client serialised the field without omitempty. An
+// ably_app whose config never sets fcm_project_id must read that back as null:
+// storing "" turns every plan into an in-place update and every apply into
+// "Provider produced inconsistent result after apply".
+func TestAccAblyApp_LegacyEmptyFCMProjectID(t *testing.T) {
+	if hermeticFake == nil {
+		t.Skip("needs the hermetic fake to seed a legacy app record")
+	}
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name     = %q
+	status   = "enabled"
+	tls_only = true
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_project_id"),
+			},
+			{
+				// A legacy client wrote fcmProjectId: "" behind Terraform's
+				// back. The refresh must map it to null so the plan is empty
+				// and the apply a no-op.
+				PreConfig: func() {
+					if !hermeticFake.setAppField(appName, "fcmProjectId", "") {
+						t.Fatalf("app %q not found in the fake", appName)
+					}
+				},
+				Config: config,
+				Check:  resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_project_id"),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_ably_app_test.go
+++ b/internal/provider/resource_ably_app_test.go
@@ -230,3 +230,47 @@ resource "ably_app" "app0" {
 		},
 	})
 }
+
+func TestAccAblyApp_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ably_app.app0", "name", appName),
+					// Computed-only fields are populated
+					resource.TestCheckResourceAttrSet("ably_app.app0", "id"),
+					resource.TestCheckResourceAttrSet("ably_app.app0", "account_id"),
+					resource.TestCheckResourceAttrSet("ably_app.app0", "created"),
+					resource.TestCheckResourceAttrSet("ably_app.app0", "modified"),
+					// Optional+Computed defaults. tls_only has no client-side
+					// default: it records whatever the server chose, which the
+					// echoing fake cannot assert on; the PlanOnly step below
+					// still proves the recorded value produces a stable plan.
+					resource.TestCheckResourceAttr("ably_app.app0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_app.app0", "apns_use_sandbox_endpoint", "false"),
+					// Optional-only fields should not be in state
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_key"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_service_account"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_project_id"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "apns_certificate"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "apns_private_key"),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "apns_signing_key"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_ably_app_unit_test.go
+++ b/internal/provider/resource_ably_app_unit_test.go
@@ -1,0 +1,63 @@
+// Package provider implements the Ably provider for Terraform
+package provider
+
+import (
+	"testing"
+
+	"github.com/ably/terraform-provider-ably/control"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestBuildAppState_FCMProjectID pins the INF-8172 behaviour: the Control API
+// returns "fcmProjectId": "" for apps last written by the pre-1.0 provider, and
+// an unset fcm_project_id must come back as null from Create, Update and Read
+// alike, including when the prior state itself still holds the "" that v1.0.0
+// wrote.
+func TestBuildAppState_FCMProjectID(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input types.String // plan on Create/Update, prior state on Read
+		api   *string
+		read  bool
+		want  types.String
+	}{
+		{name: "create/update, unset in plan, API returns empty string", input: types.StringNull(), api: ptr(""), want: types.StringNull()},
+		{name: "create/update, unset in plan, API omits the field", input: types.StringNull(), api: nil, want: types.StringNull()},
+		{name: "read, unset in prior state, API returns empty string", input: types.StringNull(), api: ptr(""), read: true, want: types.StringNull()},
+		{name: "read, v1.0.0 state holds empty string, API returns empty string", input: types.StringValue(""), api: ptr(""), read: true, want: types.StringNull()},
+		{name: "read, v1.0.0 state holds empty string, API omits the field", input: types.StringValue(""), api: nil, read: true, want: types.StringNull()},
+		{name: "create/update, set in plan, API echoes it", input: types.StringValue("project-a"), api: ptr("project-a"), want: types.StringValue("project-a")},
+		{name: "read, set in prior state, API returns it", input: types.StringValue("project-a"), api: ptr("project-a"), read: true, want: types.StringValue("project-a")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var diags diag.Diagnostics
+			rc := newReconciler(&diags)
+			if tc.read {
+				rc = rc.forRead()
+			}
+			input := AblyAppState{
+				Name:         types.StringValue("my-app"),
+				FcmProjectId: tc.input,
+			}
+			api := control.AppResponse{
+				ID:           "app-1",
+				AccountID:    "acct-1",
+				Name:         "my-app",
+				Status:       "enabled",
+				FCMProjectID: tc.api,
+			}
+			got := buildAppState(rc, input, api)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if !got.FcmProjectId.Equal(tc.want) {
+				t.Fatalf("fcm_project_id = %s, want %s", got.FcmProjectId, tc.want)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_ably_ingress_rule_mongo_test.go
+++ b/internal/provider/resource_ably_ingress_rule_mongo_test.go
@@ -86,6 +86,37 @@ func TestAccAblyIngressRuleMongo(t *testing.T) {
 	})
 }
 
+func TestAccAblyIngressRuleMongo_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalIngressRuleConfig(appName, "ably_ingress_rule_mongodb", `target = {
+		url                          = "mongodb://user:pass@example.com:27017"
+		database                     = "testdb"
+		collection                   = "testcol"
+		pipeline                     = "[]"
+		full_document                = "updateLookup"
+		full_document_before_change  = "off"
+		primary_site                 = "us-east-1-A"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_ingress_rule_mongodb.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_ingress_rule_mongodb.rule0", "status", "enabled"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyIngressRuleMongoConfig(
 	appName string,

--- a/internal/provider/resource_ably_ingress_rule_postgres_outbox_test.go
+++ b/internal/provider/resource_ably_ingress_rule_postgres_outbox_test.go
@@ -93,6 +93,37 @@ func TestAccAblyIngressRulePostgresOutbox(t *testing.T) {
 	})
 }
 
+func TestAccAblyIngressRulePostgresOutbox_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalIngressRuleConfig(appName, "ably_ingress_rule_postgres_outbox", `target = {
+		url                  = "postgres://test:test@example.com:5432/testdb"
+		outbox_table_schema  = "public"
+		outbox_table_name    = "outbox"
+		nodes_table_schema   = "public"
+		nodes_table_name     = "nodes"
+		ssl_mode             = "prefer"
+		primary_site         = "us-east-1-A"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_ingress_rule_postgres_outbox.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_ingress_rule_postgres_outbox.rule0", "status", "enabled"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyIngressRulePostgresOutboxConfig(
 	appName string,

--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -94,6 +94,21 @@ func (r ResourceKey) Metadata(ctx context.Context, req resource.MetadataRequest,
 	resp.TypeName = "ably_api_key"
 }
 
+// buildKeyState reconciles plan/state input with an API response.
+func buildKeyState(rc *reconciler, input AblyKey, api control.KeyResponse) AblyKey {
+	return AblyKey{
+		ID:              rc.str("id", input.ID, types.StringValue(api.ID), true),
+		AppID:           rc.str("app_id", input.AppID, types.StringValue(api.AppID), false),
+		Name:            rc.str("name", input.Name, types.StringValue(api.Name), false),
+		Key:             rc.str("key", input.Key, types.StringValue(api.Key), true),
+		RevocableTokens: rc.boolean("revocable_tokens", input.RevocableTokens, optBoolValue(api.RevocableTokens), true),
+		Capability:      rc.mapSet("capabilities", input.Capability, mapToTypedSet(api.Capability), false),
+		Status:          rc.int64val("status", input.Status, types.Int64Value(int64(api.Status)), true),
+		Created:         rc.int64val("created", input.Created, types.Int64Value(api.Created), true),
+		Modified:        rc.int64val("modified", input.Modified, types.Int64Value(api.Modified), true),
+	}
+}
+
 // Create creates a new resource.
 func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -148,27 +163,13 @@ func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Maps response body to resource schema attributes.
-	// Convert capability map from Go strings to Terraform types
-	tfCapability := mapToTypedSet(ablyKey.Capability)
-
-	respRevocable := false
-	if ablyKey.RevocableTokens != nil {
-		respRevocable = *ablyKey.RevocableTokens
+	rc := newReconciler(&resp.Diagnostics)
+	respKey := buildKeyState(rc, plan, ablyKey)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	respKey := AblyKey{
-		ID:              types.StringValue(ablyKey.ID),
-		AppID:           types.StringValue(ablyKey.AppID),
-		Name:            types.StringValue(ablyKey.Name),
-		Key:             types.StringValue(ablyKey.Key),
-		RevocableTokens: types.BoolValue(respRevocable),
-		Capability:      tfCapability,
-		Status:          types.Int64Value(int64(ablyKey.Status)),
-		Created:         types.Int64Value(int64(ablyKey.Created)),
-		Modified:        types.Int64Value(int64(ablyKey.Modified)),
-	}
-
-	// Sets state for the new Ably App.
+	// Sets state for the new Ably key.
 	diags = resp.State.Set(ctx, respKey)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -214,26 +215,13 @@ func (r ResourceKey) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	// Loops through apps and if account id and key id match, sets state.
 	for _, v := range keys {
 		if v.AppID == appID && v.ID == keyID && v.Status == 0 {
-			// Convert capability map from Go strings to Terraform types
-			tfCapability := mapToTypedSet(v.Capability)
-
-			vRevocable := false
-			if v.RevocableTokens != nil {
-				vRevocable = *v.RevocableTokens
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respKey := buildKeyState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 
-			respKey := AblyKey{
-				ID:              types.StringValue(v.ID),
-				AppID:           types.StringValue(v.AppID),
-				Name:            types.StringValue(v.Name),
-				RevocableTokens: types.BoolValue(vRevocable),
-				Capability:      tfCapability,
-				Status:          types.Int64Value(int64(v.Status)),
-				Key:             types.StringValue(v.Key),
-				Created:         types.Int64Value(int64(v.Created)),
-				Modified:        types.Int64Value(int64(v.Modified)),
-			}
-			// Sets state to app values.
+			// Sets state to key values.
 			diags = resp.State.Set(ctx, &respKey)
 			found = true
 
@@ -310,24 +298,10 @@ func (r ResourceKey) Update(ctx context.Context, req resource.UpdateRequest, res
 		}
 	}
 
-	// Convert capability map from Go strings to Terraform types
-	tfCapability := mapToTypedSet(ablyKey.Capability)
-
-	updateRespRevocable := false
-	if ablyKey.RevocableTokens != nil {
-		updateRespRevocable = *ablyKey.RevocableTokens
-	}
-
-	respKey := AblyKey{
-		ID:              types.StringValue(ablyKey.ID),
-		AppID:           types.StringValue(ablyKey.AppID),
-		Name:            types.StringValue(ablyKey.Name),
-		RevocableTokens: types.BoolValue(updateRespRevocable),
-		Capability:      tfCapability,
-		Status:          types.Int64Value(int64(ablyKey.Status)),
-		Key:             types.StringValue(ablyKey.Key),
-		Created:         types.Int64Value(int64(ablyKey.Created)),
-		Modified:        types.Int64Value(int64(ablyKey.Modified)),
+	rc := newReconciler(&resp.Diagnostics)
+	respKey := buildKeyState(rc, plan, ablyKey)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Sets state.

--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -69,9 +69,6 @@ func (r *ResourceKey) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"created": schema.Int64Attribute{
 				Computed:    true,
 				Description: "The timestamp of when the key was created.",
-				PlanModifiers: []planmodifier.Int64{
-					DefaultInt64Attribute(types.Int64Value(0)),
-				},
 			},
 			"key": schema.StringAttribute{
 				Computed:    true,
@@ -282,22 +279,11 @@ func (r ResourceKey) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	// Read back via GET to get settled computed fields.
-	keys, err := r.p.client.ListKeys(ctx, appID)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error reading back ably_api_key after update",
-			"Could not read back ably_api_key, unexpected error: "+err.Error(),
-		)
-		return
-	}
-	for _, k := range keys {
-		if k.ID == ablyKey.ID {
-			ablyKey = k
-			break
-		}
-	}
-
+	// Unlike Create, do not read back via GET here. On update the planned
+	// values of computed fields are the prior state values, so storing a
+	// settled `modified` that differs from the PATCH response would make
+	// Terraform report an inconsistent result after apply. The next Read
+	// picks up the settled values instead.
 	rc := newReconciler(&resp.Diagnostics)
 	respKey := buildKeyState(rc, plan, ablyKey)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -69,9 +69,6 @@ func (r *ResourceKey) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"created": schema.Int64Attribute{
 				Computed:    true,
 				Description: "The timestamp of when the key was created.",
-				PlanModifiers: []planmodifier.Int64{
-					DefaultInt64Attribute(types.Int64Value(0)),
-				},
 			},
 			"key": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/resource_ably_key.go
+++ b/internal/provider/resource_ably_key.go
@@ -91,6 +91,21 @@ func (r ResourceKey) Metadata(ctx context.Context, req resource.MetadataRequest,
 	resp.TypeName = "ably_api_key"
 }
 
+// buildKeyState reconciles plan/state input with an API response.
+func buildKeyState(rc *reconciler, input AblyKey, api control.KeyResponse) AblyKey {
+	return AblyKey{
+		ID:              rcVal(rc, "id", input.ID, types.StringValue(api.ID), true),
+		AppID:           rcVal(rc, "app_id", input.AppID, types.StringValue(api.AppID), false),
+		Name:            rcVal(rc, "name", input.Name, types.StringValue(api.Name), false),
+		Key:             rcVal(rc, "key", input.Key, types.StringValue(api.Key), true),
+		RevocableTokens: rcVal(rc, "revocable_tokens", input.RevocableTokens, optBoolValue(api.RevocableTokens), true),
+		Capability:      rcMapSet(rc, "capabilities", input.Capability, mapToTypedSet(api.Capability), false),
+		Status:          rcVal(rc, "status", input.Status, types.Int64Value(int64(api.Status)), true),
+		Created:         rcVal(rc, "created", input.Created, types.Int64Value(api.Created), true),
+		Modified:        rcVal(rc, "modified", input.Modified, types.Int64Value(api.Modified), true),
+	}
+}
+
 // Create creates a new resource.
 func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -124,6 +139,7 @@ func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, res
 		)
 		return
 	}
+	recordCreatedIdentity(ctx, resp, map[string]string{"app_id": plan.AppID.ValueString(), "id": ablyKey.ID})
 
 	// Read back the resource via GET to ensure computed fields like `modified`
 	// reflect the settled server state (the POST response may return a value
@@ -145,27 +161,13 @@ func (r ResourceKey) Create(ctx context.Context, req resource.CreateRequest, res
 	}
 
 	// Maps response body to resource schema attributes.
-	// Convert capability map from Go strings to Terraform types
-	tfCapability := mapToTypedSet(ablyKey.Capability)
-
-	respRevocable := false
-	if ablyKey.RevocableTokens != nil {
-		respRevocable = *ablyKey.RevocableTokens
+	rc := newReconciler(&resp.Diagnostics)
+	respKey := buildKeyState(rc, plan, ablyKey)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	respKey := AblyKey{
-		ID:              types.StringValue(ablyKey.ID),
-		AppID:           types.StringValue(ablyKey.AppID),
-		Name:            types.StringValue(ablyKey.Name),
-		Key:             types.StringValue(ablyKey.Key),
-		RevocableTokens: types.BoolValue(respRevocable),
-		Capability:      tfCapability,
-		Status:          types.Int64Value(int64(ablyKey.Status)),
-		Created:         types.Int64Value(int64(ablyKey.Created)),
-		Modified:        types.Int64Value(int64(ablyKey.Modified)),
-	}
-
-	// Sets state for the new Ably App.
+	// Sets state for the new Ably key.
 	diags = resp.State.Set(ctx, respKey)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -211,26 +213,13 @@ func (r ResourceKey) Read(ctx context.Context, req resource.ReadRequest, resp *r
 	// Loops through apps and if account id and key id match, sets state.
 	for _, v := range keys {
 		if v.AppID == appID && v.ID == keyID && v.Status == 0 {
-			// Convert capability map from Go strings to Terraform types
-			tfCapability := mapToTypedSet(v.Capability)
-
-			vRevocable := false
-			if v.RevocableTokens != nil {
-				vRevocable = *v.RevocableTokens
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respKey := buildKeyState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 
-			respKey := AblyKey{
-				ID:              types.StringValue(v.ID),
-				AppID:           types.StringValue(v.AppID),
-				Name:            types.StringValue(v.Name),
-				RevocableTokens: types.BoolValue(vRevocable),
-				Capability:      tfCapability,
-				Status:          types.Int64Value(int64(v.Status)),
-				Key:             types.StringValue(v.Key),
-				Created:         types.Int64Value(int64(v.Created)),
-				Modified:        types.Int64Value(int64(v.Modified)),
-			}
-			// Sets state to app values.
+			// Sets state to key values.
 			diags = resp.State.Set(ctx, &respKey)
 			found = true
 
@@ -291,7 +280,11 @@ func (r ResourceKey) Update(ctx context.Context, req resource.UpdateRequest, res
 		return
 	}
 
-	// Read back via GET to get settled computed fields.
+	// Read back via GET to get settled computed fields, as Create and the app
+	// resource do. Unconfigured computed fields (`created`, `modified`) are
+	// planned as unknown on update, so any settled value is consistent with
+	// the plan; without the read-back, a field the PATCH response omits would
+	// be stored as its zero value until the next refresh.
 	keys, err := r.p.client.ListKeys(ctx, appID)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -307,24 +300,10 @@ func (r ResourceKey) Update(ctx context.Context, req resource.UpdateRequest, res
 		}
 	}
 
-	// Convert capability map from Go strings to Terraform types
-	tfCapability := mapToTypedSet(ablyKey.Capability)
-
-	updateRespRevocable := false
-	if ablyKey.RevocableTokens != nil {
-		updateRespRevocable = *ablyKey.RevocableTokens
-	}
-
-	respKey := AblyKey{
-		ID:              types.StringValue(ablyKey.ID),
-		AppID:           types.StringValue(ablyKey.AppID),
-		Name:            types.StringValue(ablyKey.Name),
-		RevocableTokens: types.BoolValue(updateRespRevocable),
-		Capability:      tfCapability,
-		Status:          types.Int64Value(int64(ablyKey.Status)),
-		Key:             types.StringValue(ablyKey.Key),
-		Created:         types.Int64Value(int64(ablyKey.Created)),
-		Modified:        types.Int64Value(int64(ablyKey.Modified)),
+	rc := newReconciler(&resp.Diagnostics)
+	respKey := buildKeyState(rc, plan, ablyKey)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Sets state.

--- a/internal/provider/resource_ably_key_test.go
+++ b/internal/provider/resource_ably_key_test.go
@@ -108,3 +108,41 @@ resource "ably_api_key" "key0" {
   }
 `, appName, keyName, keyCapabilityName0, keyCapabilityCap0, revocableTokens)
 }
+
+func TestAccAblyKey_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource "ably_api_key" "key0" {
+	app_id = ably_app.app0.id
+	name   = "minimal-key"
+	capabilities = {
+		"channel" = ["publish"]
+	}
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_api_key.key0", "id"),
+					resource.TestCheckResourceAttrSet("ably_api_key.key0", "key"),
+					resource.TestCheckResourceAttr("ably_api_key.key0", "name", "minimal-key"),
+					// Optional+Computed default
+					resource.TestCheckResourceAttr("ably_api_key.key0", "revocable_tokens", "false"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -154,6 +154,35 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+// buildNamespaceState reconciles plan/state input with an API response.
+func buildNamespaceState(rc *reconciler, input AblyNamespace, api control.NamespaceResponse) AblyNamespace {
+	ns := AblyNamespace{
+		AppID:                   rc.str("app_id", input.AppID, types.StringValue(api.AppID), false),
+		ID:                      rc.str("id", input.ID, types.StringValue(api.ID), false),
+		Authenticated:           rc.boolean("authenticated", input.Authenticated, types.BoolValue(api.Authenticated), true),
+		Persisted:               rc.boolean("persisted", input.Persisted, types.BoolValue(api.Persisted), true),
+		PersistLast:             rc.boolean("persist_last", input.PersistLast, types.BoolValue(api.PersistLast), true),
+		PushEnabled:             rc.boolean("push_enabled", input.PushEnabled, types.BoolValue(api.PushEnabled), true),
+		TlsOnly:                 rc.boolean("tls_only", input.TlsOnly, types.BoolValue(api.TLSOnly), true),
+		ExposeTimeserial:        rc.boolean("expose_timeserial", input.ExposeTimeserial, types.BoolValue(api.ExposeTimeserial), true),
+		MutableMessages:         rc.boolean("mutable_messages", input.MutableMessages, types.BoolValue(api.MutableMessages), true),
+		PopulateChannelRegistry: rc.boolean("populate_channel_registry", input.PopulateChannelRegistry, types.BoolValue(api.PopulateChannelRegistry), true),
+		BatchingEnabled:         rc.boolean("batching_enabled", input.BatchingEnabled, optBoolValue(api.BatchingEnabled), true),
+		ConflationEnabled:       rc.boolean("conflation_enabled", input.ConflationEnabled, optBoolValue(api.ConflationEnabled), true),
+	}
+
+	if api.BatchingEnabled != nil && *api.BatchingEnabled {
+		ns.BatchingInterval = rc.int64val("batching_interval", input.BatchingInterval, optIntValue(api.BatchingInterval), true)
+	}
+
+	if api.ConflationEnabled != nil && *api.ConflationEnabled {
+		ns.ConflationInterval = rc.int64val("conflation_interval", input.ConflationInterval, optIntValue(api.ConflationInterval), true)
+		ns.ConflationKey = rc.str("conflation_key", input.ConflationKey, optStringValue(api.ConflationKey), true)
+	}
+
+	return ns
+}
+
 // Create creates a new resource.
 func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -210,32 +239,14 @@ func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyNamespace{
-		AppID:                   types.StringValue(plan.AppID.ValueString()),
-		ID:                      types.StringValue(ablyNamespace.ID),
-		Authenticated:           types.BoolValue(ablyNamespace.Authenticated),
-		Persisted:               types.BoolValue(ablyNamespace.Persisted),
-		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
-		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
-		TlsOnly:                 types.BoolValue(ablyNamespace.TLSOnly),
-		ExposeTimeserial:        types.BoolValue(ablyNamespace.ExposeTimeserial),
-		MutableMessages:         types.BoolValue(ablyNamespace.MutableMessages),
-		PopulateChannelRegistry: types.BoolValue(ablyNamespace.PopulateChannelRegistry),
-		BatchingEnabled:         optBoolValue(ablyNamespace.BatchingEnabled),
-		ConflationEnabled:       optBoolValue(ablyNamespace.ConflationEnabled),
+	rc := newReconciler(&resp.Diagnostics)
+	respNs := buildNamespaceState(rc, plan, ablyNamespace)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if ablyNamespace.BatchingEnabled != nil && *ablyNamespace.BatchingEnabled {
-		respApps.BatchingInterval = optIntValue(ablyNamespace.BatchingInterval)
-	}
-
-	if ablyNamespace.ConflationEnabled != nil && *ablyNamespace.ConflationEnabled {
-		respApps.ConflationInterval = optIntValue(ablyNamespace.ConflationInterval)
-		respApps.ConflationKey = optStringValue(ablyNamespace.ConflationKey)
-	}
-
-	// Sets state for the new Ably App.
-	diags = resp.State.Set(ctx, respApps)
+	// Sets state for the new Ably namespace.
+	diags = resp.State.Set(ctx, respNs)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -284,32 +295,14 @@ func (r ResourceNamespace) Read(ctx context.Context, req resource.ReadRequest, r
 	// Loops through namespaces and if id matches, sets state.
 	for _, v := range namespaces {
 		if v.ID == namespaceID {
-			respNamespaces := AblyNamespace{
-				AppID:                   types.StringValue(appID),
-				ID:                      types.StringValue(namespaceID),
-				Authenticated:           types.BoolValue(v.Authenticated),
-				Persisted:               types.BoolValue(v.Persisted),
-				PersistLast:             types.BoolValue(v.PersistLast),
-				PushEnabled:             types.BoolValue(v.PushEnabled),
-				TlsOnly:                 types.BoolValue(v.TLSOnly),
-				ExposeTimeserial:        types.BoolValue(v.ExposeTimeserial),
-				MutableMessages:         types.BoolValue(v.MutableMessages),
-				PopulateChannelRegistry: types.BoolValue(v.PopulateChannelRegistry),
-				BatchingEnabled:         optBoolValue(v.BatchingEnabled),
-				ConflationEnabled:       optBoolValue(v.ConflationEnabled),
-			}
-
-			if v.BatchingEnabled != nil && *v.BatchingEnabled {
-				respNamespaces.BatchingInterval = optIntValue(v.BatchingInterval)
-			}
-
-			if v.ConflationEnabled != nil && *v.ConflationEnabled {
-				respNamespaces.ConflationInterval = optIntValue(v.ConflationInterval)
-				respNamespaces.ConflationKey = optStringValue(v.ConflationKey)
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respNs := buildNamespaceState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 
 			// Sets state to namespace values.
-			diags = resp.State.Set(ctx, &respNamespaces)
+			diags = resp.State.Set(ctx, &respNs)
 			found = true
 
 			resp.Diagnostics.Append(diags...)
@@ -385,32 +378,14 @@ func (r ResourceNamespace) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	respNamespaces := AblyNamespace{
-		AppID:                   types.StringValue(appID),
-		ID:                      types.StringValue(ablyNamespace.ID),
-		Authenticated:           types.BoolValue(ablyNamespace.Authenticated),
-		Persisted:               types.BoolValue(ablyNamespace.Persisted),
-		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
-		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
-		TlsOnly:                 types.BoolValue(ablyNamespace.TLSOnly),
-		ExposeTimeserial:        types.BoolValue(ablyNamespace.ExposeTimeserial),
-		MutableMessages:         types.BoolValue(ablyNamespace.MutableMessages),
-		PopulateChannelRegistry: types.BoolValue(ablyNamespace.PopulateChannelRegistry),
-		BatchingEnabled:         optBoolValue(ablyNamespace.BatchingEnabled),
-		ConflationEnabled:       optBoolValue(ablyNamespace.ConflationEnabled),
-	}
-
-	if ablyNamespace.BatchingEnabled != nil && *ablyNamespace.BatchingEnabled {
-		respNamespaces.BatchingInterval = optIntValue(ablyNamespace.BatchingInterval)
-	}
-
-	if ablyNamespace.ConflationEnabled != nil && *ablyNamespace.ConflationEnabled {
-		respNamespaces.ConflationInterval = optIntValue(ablyNamespace.ConflationInterval)
-		respNamespaces.ConflationKey = optStringValue(ablyNamespace.ConflationKey)
+	rc := newReconciler(&resp.Diagnostics)
+	respNs := buildNamespaceState(rc, plan, ablyNamespace)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Sets state to new namespace.
-	diags = resp.State.Set(ctx, respNamespaces)
+	diags = resp.State.Set(ctx, respNs)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -351,7 +351,7 @@ func (r ResourceNamespace) Read(ctx context.Context, req resource.ReadRequest, r
 			}
 
 			// Sets state to namespace values.
-			diags = resp.State.Set(ctx, &respNamespaces)
+			diags = resp.State.Set(ctx, &respNs)
 			found = true
 
 			resp.Diagnostics.Append(diags...)
@@ -453,7 +453,7 @@ func (r ResourceNamespace) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	// Sets state to new namespace.
-	diags = resp.State.Set(ctx, respNamespaces)
+	diags = resp.State.Set(ctx, respNs)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -194,6 +194,56 @@ func namespaceIdentifiedValue(n control.NamespaceResponse) bool {
 	return n.Authenticated
 }
 
+// buildNamespaceState reconciles plan/state input with an API response.
+func buildNamespaceState(rc *reconciler, input AblyNamespace, api control.NamespaceResponse) AblyNamespace {
+	// identified and authenticated are aliases of a single server-side setting.
+	// The schema keeps them mirrored, so both always take the server's value
+	// and bypass per-field reconciliation.
+	identified := types.BoolValue(namespaceIdentifiedValue(api))
+
+	ns := AblyNamespace{
+		AppID:                   rc.str("app_id", input.AppID, types.StringValue(api.AppID), false),
+		ID:                      rc.str("id", input.ID, types.StringValue(api.ID), false),
+		Identified:              identified,
+		Authenticated:           identified,
+		Persisted:               rc.boolean("persisted", input.Persisted, types.BoolValue(api.Persisted), true),
+		PersistLast:             rc.boolean("persist_last", input.PersistLast, types.BoolValue(api.PersistLast), true),
+		PushEnabled:             rc.boolean("push_enabled", input.PushEnabled, types.BoolValue(api.PushEnabled), true),
+		TlsOnly:                 rc.boolean("tls_only", input.TlsOnly, types.BoolValue(api.TLSOnly), true),
+		ExposeTimeserial:        rc.boolean("expose_timeserial", input.ExposeTimeserial, types.BoolValue(api.ExposeTimeserial), true),
+		MutableMessages:         rc.boolean("mutable_messages", input.MutableMessages, types.BoolValue(api.MutableMessages), true),
+		PopulateChannelRegistry: rc.boolean("populate_channel_registry", input.PopulateChannelRegistry, types.BoolValue(api.PopulateChannelRegistry), true),
+		BatchingEnabled:         rc.boolean("batching_enabled", input.BatchingEnabled, optBoolValue(api.BatchingEnabled), true),
+		ConflationEnabled:       rc.boolean("conflation_enabled", input.ConflationEnabled, optBoolValue(api.ConflationEnabled), true),
+	}
+
+	// A nil enabled flag means the response omitted the field, not that the
+	// feature is off: keep the planned interval/key values in that case and
+	// only clear them when the API explicitly reports the feature disabled.
+	switch {
+	case api.BatchingEnabled == nil:
+		ns.BatchingInterval = rc.int64val("batching_interval", input.BatchingInterval, types.Int64Null(), true)
+	case *api.BatchingEnabled:
+		ns.BatchingInterval = rc.int64val("batching_interval", input.BatchingInterval, optIntValue(api.BatchingInterval), true)
+	default:
+		ns.BatchingInterval = types.Int64Null()
+	}
+
+	switch {
+	case api.ConflationEnabled == nil:
+		ns.ConflationInterval = rc.int64val("conflation_interval", input.ConflationInterval, types.Int64Null(), true)
+		ns.ConflationKey = rc.str("conflation_key", input.ConflationKey, types.StringNull(), true)
+	case *api.ConflationEnabled:
+		ns.ConflationInterval = rc.int64val("conflation_interval", input.ConflationInterval, optIntValue(api.ConflationInterval), true)
+		ns.ConflationKey = rc.str("conflation_key", input.ConflationKey, optStringValue(api.ConflationKey), true)
+	default:
+		ns.ConflationInterval = types.Int64Null()
+		ns.ConflationKey = types.StringNull()
+	}
+
+	return ns
+}
+
 // Create creates a new resource.
 func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -250,33 +300,14 @@ func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateReques
 	}
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyNamespace{
-		AppID:                   types.StringValue(plan.AppID.ValueString()),
-		ID:                      types.StringValue(ablyNamespace.ID),
-		Identified:              types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Authenticated:           types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Persisted:               types.BoolValue(ablyNamespace.Persisted),
-		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
-		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
-		TlsOnly:                 types.BoolValue(ablyNamespace.TLSOnly),
-		ExposeTimeserial:        types.BoolValue(ablyNamespace.ExposeTimeserial),
-		MutableMessages:         types.BoolValue(ablyNamespace.MutableMessages),
-		PopulateChannelRegistry: types.BoolValue(ablyNamespace.PopulateChannelRegistry),
-		BatchingEnabled:         optBoolValue(ablyNamespace.BatchingEnabled),
-		ConflationEnabled:       optBoolValue(ablyNamespace.ConflationEnabled),
+	rc := newReconciler(&resp.Diagnostics)
+	respNs := buildNamespaceState(rc, plan, ablyNamespace)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if ablyNamespace.BatchingEnabled != nil && *ablyNamespace.BatchingEnabled {
-		respApps.BatchingInterval = optIntValue(ablyNamespace.BatchingInterval)
-	}
-
-	if ablyNamespace.ConflationEnabled != nil && *ablyNamespace.ConflationEnabled {
-		respApps.ConflationInterval = optIntValue(ablyNamespace.ConflationInterval)
-		respApps.ConflationKey = optStringValue(ablyNamespace.ConflationKey)
-	}
-
-	// Sets state for the new Ably App.
-	diags = resp.State.Set(ctx, respApps)
+	// Sets state for the new Ably namespace.
+	diags = resp.State.Set(ctx, respNs)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -325,29 +356,10 @@ func (r ResourceNamespace) Read(ctx context.Context, req resource.ReadRequest, r
 	// Loops through namespaces and if id matches, sets state.
 	for _, v := range namespaces {
 		if v.ID == namespaceID {
-			respNamespaces := AblyNamespace{
-				AppID:                   types.StringValue(appID),
-				ID:                      types.StringValue(namespaceID),
-				Identified:              types.BoolValue(namespaceIdentifiedValue(v)),
-				Authenticated:           types.BoolValue(namespaceIdentifiedValue(v)),
-				Persisted:               types.BoolValue(v.Persisted),
-				PersistLast:             types.BoolValue(v.PersistLast),
-				PushEnabled:             types.BoolValue(v.PushEnabled),
-				TlsOnly:                 types.BoolValue(v.TLSOnly),
-				ExposeTimeserial:        types.BoolValue(v.ExposeTimeserial),
-				MutableMessages:         types.BoolValue(v.MutableMessages),
-				PopulateChannelRegistry: types.BoolValue(v.PopulateChannelRegistry),
-				BatchingEnabled:         optBoolValue(v.BatchingEnabled),
-				ConflationEnabled:       optBoolValue(v.ConflationEnabled),
-			}
-
-			if v.BatchingEnabled != nil && *v.BatchingEnabled {
-				respNamespaces.BatchingInterval = optIntValue(v.BatchingInterval)
-			}
-
-			if v.ConflationEnabled != nil && *v.ConflationEnabled {
-				respNamespaces.ConflationInterval = optIntValue(v.ConflationInterval)
-				respNamespaces.ConflationKey = optStringValue(v.ConflationKey)
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respNs := buildNamespaceState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 
 			// Sets state to namespace values.
@@ -427,29 +439,10 @@ func (r ResourceNamespace) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	respNamespaces := AblyNamespace{
-		AppID:                   types.StringValue(appID),
-		ID:                      types.StringValue(ablyNamespace.ID),
-		Identified:              types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Authenticated:           types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Persisted:               types.BoolValue(ablyNamespace.Persisted),
-		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
-		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
-		TlsOnly:                 types.BoolValue(ablyNamespace.TLSOnly),
-		ExposeTimeserial:        types.BoolValue(ablyNamespace.ExposeTimeserial),
-		MutableMessages:         types.BoolValue(ablyNamespace.MutableMessages),
-		PopulateChannelRegistry: types.BoolValue(ablyNamespace.PopulateChannelRegistry),
-		BatchingEnabled:         optBoolValue(ablyNamespace.BatchingEnabled),
-		ConflationEnabled:       optBoolValue(ablyNamespace.ConflationEnabled),
-	}
-
-	if ablyNamespace.BatchingEnabled != nil && *ablyNamespace.BatchingEnabled {
-		respNamespaces.BatchingInterval = optIntValue(ablyNamespace.BatchingInterval)
-	}
-
-	if ablyNamespace.ConflationEnabled != nil && *ablyNamespace.ConflationEnabled {
-		respNamespaces.ConflationInterval = optIntValue(ablyNamespace.ConflationInterval)
-		respNamespaces.ConflationKey = optStringValue(ablyNamespace.ConflationKey)
+	rc := newReconciler(&resp.Diagnostics)
+	respNs := buildNamespaceState(rc, plan, ablyNamespace)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Sets state to new namespace.

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -132,9 +132,6 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				Description: "When configured, sets the maximum batching interval in the channel.",
-				PlanModifiers: []planmodifier.Int64{
-					DefaultInt64Attribute(types.Int64Null()),
-				},
 				Validators: []validator.Int64{
 					int64validator.AtLeast(0),
 				},
@@ -151,9 +148,6 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				Description: "The interval in milliseconds at which messages are conflated. This determines how frequently messages are combined into a single message.",
-				PlanModifiers: []planmodifier.Int64{
-					DefaultInt64Attribute(types.Int64Null()),
-				},
 				Validators: []validator.Int64{
 					int64validator.AtLeast(0),
 				},
@@ -162,9 +156,6 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				Description: "The key used to determine which messages should be conflated. Messages with the same conflation key will be combined into a single message.",
-				PlanModifiers: []planmodifier.String{
-					DefaultStringAttribute(types.StringNull()),
-				},
 			},
 		},
 		MarkdownDescription: "The Ably namespace resource allows you to manage namespaces for channel rules in Ably. Read more in the Ably documentation: https://ably.com/docs/general/channel-rules-namespaces.",

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -185,6 +185,56 @@ func namespaceIdentifiedValue(n control.NamespaceResponse) bool {
 	return n.Authenticated
 }
 
+// buildNamespaceState reconciles plan/state input with an API response.
+func buildNamespaceState(rc *reconciler, input AblyNamespace, api control.NamespaceResponse) AblyNamespace {
+	// identified and authenticated are aliases of a single server-side setting.
+	// The schema keeps them mirrored, so both always take the server's value
+	// and bypass per-field reconciliation.
+	identified := types.BoolValue(namespaceIdentifiedValue(api))
+
+	ns := AblyNamespace{
+		AppID:                   rcVal(rc, "app_id", input.AppID, types.StringValue(api.AppID), false),
+		ID:                      rcVal(rc, "id", input.ID, types.StringValue(api.ID), false),
+		Identified:              identified,
+		Authenticated:           identified,
+		Persisted:               rcVal(rc, "persisted", input.Persisted, types.BoolValue(api.Persisted), true),
+		PersistLast:             rcVal(rc, "persist_last", input.PersistLast, types.BoolValue(api.PersistLast), true),
+		PushEnabled:             rcVal(rc, "push_enabled", input.PushEnabled, types.BoolValue(api.PushEnabled), true),
+		TlsOnly:                 rcVal(rc, "tls_only", input.TlsOnly, types.BoolValue(api.TLSOnly), true),
+		ExposeTimeserial:        rcVal(rc, "expose_timeserial", input.ExposeTimeserial, types.BoolValue(api.ExposeTimeserial), true),
+		MutableMessages:         rcVal(rc, "mutable_messages", input.MutableMessages, types.BoolValue(api.MutableMessages), true),
+		PopulateChannelRegistry: rcVal(rc, "populate_channel_registry", input.PopulateChannelRegistry, types.BoolValue(api.PopulateChannelRegistry), true),
+		BatchingEnabled:         rcVal(rc, "batching_enabled", input.BatchingEnabled, optBoolValue(api.BatchingEnabled), true),
+		ConflationEnabled:       rcVal(rc, "conflation_enabled", input.ConflationEnabled, optBoolValue(api.ConflationEnabled), true),
+	}
+
+	// A nil enabled flag means the response omitted the field, not that the
+	// feature is off: keep the planned interval/key values in that case and
+	// only clear them when the API explicitly reports the feature disabled.
+	switch {
+	case api.BatchingEnabled == nil:
+		ns.BatchingInterval = rcVal(rc, "batching_interval", input.BatchingInterval, types.Int64Null(), true)
+	case *api.BatchingEnabled:
+		ns.BatchingInterval = rcVal(rc, "batching_interval", input.BatchingInterval, optIntValue(api.BatchingInterval), true)
+	default:
+		ns.BatchingInterval = types.Int64Null()
+	}
+
+	switch {
+	case api.ConflationEnabled == nil:
+		ns.ConflationInterval = rcVal(rc, "conflation_interval", input.ConflationInterval, types.Int64Null(), true)
+		ns.ConflationKey = rcVal(rc, "conflation_key", input.ConflationKey, types.StringNull(), true)
+	case *api.ConflationEnabled:
+		ns.ConflationInterval = rcVal(rc, "conflation_interval", input.ConflationInterval, optIntValue(api.ConflationInterval), true)
+		ns.ConflationKey = rcVal(rc, "conflation_key", input.ConflationKey, optStringValue(api.ConflationKey), true)
+	default:
+		ns.ConflationInterval = types.Int64Null()
+		ns.ConflationKey = types.StringNull()
+	}
+
+	return ns
+}
+
 // Create creates a new resource.
 func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -239,35 +289,17 @@ func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateReques
 		)
 		return
 	}
+	recordCreatedIdentity(ctx, resp, map[string]string{"app_id": plan.AppID.ValueString(), "id": ablyNamespace.ID})
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyNamespace{
-		AppID:                   types.StringValue(plan.AppID.ValueString()),
-		ID:                      types.StringValue(ablyNamespace.ID),
-		Identified:              types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Authenticated:           types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Persisted:               types.BoolValue(ablyNamespace.Persisted),
-		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
-		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
-		TlsOnly:                 types.BoolValue(ablyNamespace.TLSOnly),
-		ExposeTimeserial:        types.BoolValue(ablyNamespace.ExposeTimeserial),
-		MutableMessages:         types.BoolValue(ablyNamespace.MutableMessages),
-		PopulateChannelRegistry: types.BoolValue(ablyNamespace.PopulateChannelRegistry),
-		BatchingEnabled:         optBoolValue(ablyNamespace.BatchingEnabled),
-		ConflationEnabled:       optBoolValue(ablyNamespace.ConflationEnabled),
+	rc := newReconciler(&resp.Diagnostics)
+	respNs := buildNamespaceState(rc, plan, ablyNamespace)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	if ablyNamespace.BatchingEnabled != nil && *ablyNamespace.BatchingEnabled {
-		respApps.BatchingInterval = optIntValue(ablyNamespace.BatchingInterval)
-	}
-
-	if ablyNamespace.ConflationEnabled != nil && *ablyNamespace.ConflationEnabled {
-		respApps.ConflationInterval = optIntValue(ablyNamespace.ConflationInterval)
-		respApps.ConflationKey = optStringValue(ablyNamespace.ConflationKey)
-	}
-
-	// Sets state for the new Ably App.
-	diags = resp.State.Set(ctx, respApps)
+	// Sets state for the new Ably namespace.
+	diags = resp.State.Set(ctx, respNs)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -316,33 +348,14 @@ func (r ResourceNamespace) Read(ctx context.Context, req resource.ReadRequest, r
 	// Loops through namespaces and if id matches, sets state.
 	for _, v := range namespaces {
 		if v.ID == namespaceID {
-			respNamespaces := AblyNamespace{
-				AppID:                   types.StringValue(appID),
-				ID:                      types.StringValue(namespaceID),
-				Identified:              types.BoolValue(namespaceIdentifiedValue(v)),
-				Authenticated:           types.BoolValue(namespaceIdentifiedValue(v)),
-				Persisted:               types.BoolValue(v.Persisted),
-				PersistLast:             types.BoolValue(v.PersistLast),
-				PushEnabled:             types.BoolValue(v.PushEnabled),
-				TlsOnly:                 types.BoolValue(v.TLSOnly),
-				ExposeTimeserial:        types.BoolValue(v.ExposeTimeserial),
-				MutableMessages:         types.BoolValue(v.MutableMessages),
-				PopulateChannelRegistry: types.BoolValue(v.PopulateChannelRegistry),
-				BatchingEnabled:         optBoolValue(v.BatchingEnabled),
-				ConflationEnabled:       optBoolValue(v.ConflationEnabled),
-			}
-
-			if v.BatchingEnabled != nil && *v.BatchingEnabled {
-				respNamespaces.BatchingInterval = optIntValue(v.BatchingInterval)
-			}
-
-			if v.ConflationEnabled != nil && *v.ConflationEnabled {
-				respNamespaces.ConflationInterval = optIntValue(v.ConflationInterval)
-				respNamespaces.ConflationKey = optStringValue(v.ConflationKey)
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respNs := buildNamespaceState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 
 			// Sets state to namespace values.
-			diags = resp.State.Set(ctx, &respNamespaces)
+			diags = resp.State.Set(ctx, &respNs)
 			found = true
 
 			resp.Diagnostics.Append(diags...)
@@ -418,33 +431,14 @@ func (r ResourceNamespace) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	respNamespaces := AblyNamespace{
-		AppID:                   types.StringValue(appID),
-		ID:                      types.StringValue(ablyNamespace.ID),
-		Identified:              types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Authenticated:           types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
-		Persisted:               types.BoolValue(ablyNamespace.Persisted),
-		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
-		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
-		TlsOnly:                 types.BoolValue(ablyNamespace.TLSOnly),
-		ExposeTimeserial:        types.BoolValue(ablyNamespace.ExposeTimeserial),
-		MutableMessages:         types.BoolValue(ablyNamespace.MutableMessages),
-		PopulateChannelRegistry: types.BoolValue(ablyNamespace.PopulateChannelRegistry),
-		BatchingEnabled:         optBoolValue(ablyNamespace.BatchingEnabled),
-		ConflationEnabled:       optBoolValue(ablyNamespace.ConflationEnabled),
-	}
-
-	if ablyNamespace.BatchingEnabled != nil && *ablyNamespace.BatchingEnabled {
-		respNamespaces.BatchingInterval = optIntValue(ablyNamespace.BatchingInterval)
-	}
-
-	if ablyNamespace.ConflationEnabled != nil && *ablyNamespace.ConflationEnabled {
-		respNamespaces.ConflationInterval = optIntValue(ablyNamespace.ConflationInterval)
-		respNamespaces.ConflationKey = optStringValue(ablyNamespace.ConflationKey)
+	rc := newReconciler(&resp.Diagnostics)
+	respNs := buildNamespaceState(rc, plan, ablyNamespace)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Sets state to new namespace.
-	diags = resp.State.Set(ctx, respNamespaces)
+	diags = resp.State.Set(ctx, respNs)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_ably_namespace_test.go
+++ b/internal/provider/resource_ably_namespace_test.go
@@ -302,6 +302,49 @@ resource "ably_namespace" "namespace0" {
 	)
 }
 
+func TestAccAblyNamespace_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource "ably_namespace" "ns0" {
+	app_id = ably_app.app0.id
+	id     = "minimal-ns"
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_namespace.ns0", "app_id"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "id", "minimal-ns"),
+					// Optional+Computed defaults (all false)
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "authenticated", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "persisted", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "persist_last", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "push_enabled", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "tls_only", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "expose_timeserial", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "mutable_messages", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "populate_channel_registry", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "batching_enabled", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "conflation_enabled", "false"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccAblyNamespace_InvalidBatchingInterval(t *testing.T) {
 	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_ably_namespace_test.go
+++ b/internal/provider/resource_ably_namespace_test.go
@@ -392,6 +392,50 @@ resource "ably_namespace" "ns0" {
 	})
 }
 
+func TestAccAblyNamespace_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource "ably_namespace" "ns0" {
+	app_id = ably_app.app0.id
+	id     = "minimal-ns"
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_namespace.ns0", "app_id"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "id", "minimal-ns"),
+					// Optional+Computed defaults (all false)
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "identified", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "authenticated", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "persisted", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "persist_last", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "push_enabled", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "tls_only", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "expose_timeserial", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "mutable_messages", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "populate_channel_registry", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "batching_enabled", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.ns0", "conflation_enabled", "false"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccAblyNamespace_InvalidBatchingInterval(t *testing.T) {
 	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_ably_queue.go
+++ b/internal/provider/resource_ably_queue.go
@@ -136,6 +136,26 @@ func (r ResourceQueue) Metadata(ctx context.Context, req resource.MetadataReques
 	resp.TypeName = "ably_queue"
 }
 
+// buildQueueState reconciles plan/state input with an API response.
+func buildQueueState(rc *reconciler, input AblyQueue, api control.QueueResponse) AblyQueue {
+	return AblyQueue{
+		AppID:            rc.str("app_id", input.AppID, types.StringValue(api.AppID), false),
+		ID:               rc.str("id", input.ID, types.StringValue(api.ID), true),
+		Name:             rc.str("name", input.Name, types.StringValue(api.Name), false),
+		Ttl:              rc.int64val("ttl", input.Ttl, types.Int64Value(int64(api.TTL)), false),
+		MaxLength:        rc.int64val("max_length", input.MaxLength, types.Int64Value(int64(api.MaxLength)), false),
+		Region:           rc.str("region", input.Region, types.StringValue(api.Region), false),
+		AmqpUri:          rc.str("amqp_uri", input.AmqpUri, types.StringValue(api.AMQP.URI), true),
+		AmqpQueueName:    rc.str("amqp_queue_name", input.AmqpQueueName, types.StringValue(api.AMQP.QueueName), true),
+		StompURI:         rc.str("stomp_uri", input.StompURI, types.StringValue(api.Stomp.URI), true),
+		StompHost:        rc.str("stomp_host", input.StompHost, types.StringValue(api.Stomp.Host), true),
+		StompDestination: rc.str("stomp_destination", input.StompDestination, types.StringValue(api.Stomp.Destination), true),
+		State:            rc.str("state", input.State, types.StringValue(api.State), true),
+		Deadletter:       rc.boolean("deadletter", input.Deadletter, types.BoolValue(api.Deadletter), true),
+		DeadletterID:     rc.str("deadletter_id", input.DeadletterID, optStringValue(api.DeadletterID), true),
+	}
+}
+
 // Create creates a new resource.
 func (r ResourceQueue) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -169,26 +189,14 @@ func (r ResourceQueue) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyQueue{
-		AppID:     types.StringValue(plan.AppID.ValueString()),
-		ID:        types.StringValue(ablyQueue.ID),
-		Name:      types.StringValue(ablyQueue.Name),
-		Ttl:       types.Int64Value(int64(ablyQueue.TTL)),
-		MaxLength: types.Int64Value(int64(ablyQueue.MaxLength)),
-		Region:    types.StringValue(ablyQueue.Region),
-
-		AmqpUri:          types.StringValue(ablyQueue.AMQP.URI),
-		AmqpQueueName:    types.StringValue(ablyQueue.AMQP.QueueName),
-		StompURI:         types.StringValue(ablyQueue.Stomp.URI),
-		StompHost:        types.StringValue(ablyQueue.Stomp.Host),
-		StompDestination: types.StringValue(ablyQueue.Stomp.Destination),
-		State:            types.StringValue(ablyQueue.State),
-		Deadletter:       types.BoolValue(ablyQueue.Deadletter),
-		DeadletterID:     optStringValue(ablyQueue.DeadletterID),
+	rc := newReconciler(&resp.Diagnostics)
+	respQueue := buildQueueState(rc, plan, ablyQueue)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	// Sets state for the new Ably App.
-	diags = resp.State.Set(ctx, respApps)
+	// Sets state for the new Ably queue.
+	diags = resp.State.Set(ctx, respQueue)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -233,25 +241,14 @@ func (r ResourceQueue) Read(ctx context.Context, req resource.ReadRequest, resp 
 	// Loops through queues and if id matches, sets state.
 	for _, v := range queues {
 		if v.ID == queueID {
-			respQueues := AblyQueue{
-				AppID:     types.StringValue(v.AppID),
-				ID:        types.StringValue(v.ID),
-				Name:      types.StringValue(v.Name),
-				Ttl:       types.Int64Value(int64(v.TTL)),
-				MaxLength: types.Int64Value(int64(v.MaxLength)),
-				Region:    types.StringValue(v.Region),
-
-				AmqpUri:          types.StringValue(v.AMQP.URI),
-				AmqpQueueName:    types.StringValue(v.AMQP.QueueName),
-				StompURI:         types.StringValue(v.Stomp.URI),
-				StompHost:        types.StringValue(v.Stomp.Host),
-				StompDestination: types.StringValue(v.Stomp.Destination),
-				State:            types.StringValue(v.State),
-				Deadletter:       types.BoolValue(v.Deadletter),
-				DeadletterID:     optStringValue(v.DeadletterID),
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respQueue := buildQueueState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
+
 			// Sets state to queue values.
-			diags = resp.State.Set(ctx, &respQueues)
+			diags = resp.State.Set(ctx, &respQueue)
 			found = true
 
 			resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_ably_queue.go
+++ b/internal/provider/resource_ably_queue.go
@@ -136,6 +136,26 @@ func (r ResourceQueue) Metadata(ctx context.Context, req resource.MetadataReques
 	resp.TypeName = "ably_queue"
 }
 
+// buildQueueState reconciles plan/state input with an API response.
+func buildQueueState(rc *reconciler, input AblyQueue, api control.QueueResponse) AblyQueue {
+	return AblyQueue{
+		AppID:            rcVal(rc, "app_id", input.AppID, types.StringValue(api.AppID), false),
+		ID:               rcVal(rc, "id", input.ID, types.StringValue(api.ID), true),
+		Name:             rcVal(rc, "name", input.Name, types.StringValue(api.Name), false),
+		Ttl:              rcVal(rc, "ttl", input.Ttl, types.Int64Value(int64(api.TTL)), false),
+		MaxLength:        rcVal(rc, "max_length", input.MaxLength, types.Int64Value(int64(api.MaxLength)), false),
+		Region:           rcVal(rc, "region", input.Region, types.StringValue(api.Region), false),
+		AmqpUri:          rcVal(rc, "amqp_uri", input.AmqpUri, types.StringValue(api.AMQP.URI), true),
+		AmqpQueueName:    rcVal(rc, "amqp_queue_name", input.AmqpQueueName, types.StringValue(api.AMQP.QueueName), true),
+		StompURI:         rcVal(rc, "stomp_uri", input.StompURI, types.StringValue(api.Stomp.URI), true),
+		StompHost:        rcVal(rc, "stomp_host", input.StompHost, types.StringValue(api.Stomp.Host), true),
+		StompDestination: rcVal(rc, "stomp_destination", input.StompDestination, types.StringValue(api.Stomp.Destination), true),
+		State:            rcVal(rc, "state", input.State, types.StringValue(api.State), true),
+		Deadletter:       rcVal(rc, "deadletter", input.Deadletter, types.BoolValue(api.Deadletter), true),
+		DeadletterID:     rcVal(rc, "deadletter_id", input.DeadletterID, optStringValue(api.DeadletterID), true),
+	}
+}
+
 // Create creates a new resource.
 func (r ResourceQueue) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -167,28 +187,17 @@ func (r ResourceQueue) Create(ctx context.Context, req resource.CreateRequest, r
 		)
 		return
 	}
+	recordCreatedIdentity(ctx, resp, map[string]string{"app_id": plan.AppID.ValueString(), "id": ablyQueue.ID})
 
 	// Maps response body to resource schema attributes.
-	respApps := AblyQueue{
-		AppID:     types.StringValue(plan.AppID.ValueString()),
-		ID:        types.StringValue(ablyQueue.ID),
-		Name:      types.StringValue(ablyQueue.Name),
-		Ttl:       types.Int64Value(int64(ablyQueue.TTL)),
-		MaxLength: types.Int64Value(int64(ablyQueue.MaxLength)),
-		Region:    types.StringValue(ablyQueue.Region),
-
-		AmqpUri:          types.StringValue(ablyQueue.AMQP.URI),
-		AmqpQueueName:    types.StringValue(ablyQueue.AMQP.QueueName),
-		StompURI:         types.StringValue(ablyQueue.Stomp.URI),
-		StompHost:        types.StringValue(ablyQueue.Stomp.Host),
-		StompDestination: types.StringValue(ablyQueue.Stomp.Destination),
-		State:            types.StringValue(ablyQueue.State),
-		Deadletter:       types.BoolValue(ablyQueue.Deadletter),
-		DeadletterID:     optStringValue(ablyQueue.DeadletterID),
+	rc := newReconciler(&resp.Diagnostics)
+	respQueue := buildQueueState(rc, plan, ablyQueue)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	// Sets state for the new Ably App.
-	diags = resp.State.Set(ctx, respApps)
+	// Sets state for the new Ably queue.
+	diags = resp.State.Set(ctx, respQueue)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -233,25 +242,14 @@ func (r ResourceQueue) Read(ctx context.Context, req resource.ReadRequest, resp 
 	// Loops through queues and if id matches, sets state.
 	for _, v := range queues {
 		if v.ID == queueID {
-			respQueues := AblyQueue{
-				AppID:     types.StringValue(v.AppID),
-				ID:        types.StringValue(v.ID),
-				Name:      types.StringValue(v.Name),
-				Ttl:       types.Int64Value(int64(v.TTL)),
-				MaxLength: types.Int64Value(int64(v.MaxLength)),
-				Region:    types.StringValue(v.Region),
-
-				AmqpUri:          types.StringValue(v.AMQP.URI),
-				AmqpQueueName:    types.StringValue(v.AMQP.QueueName),
-				StompURI:         types.StringValue(v.Stomp.URI),
-				StompHost:        types.StringValue(v.Stomp.Host),
-				StompDestination: types.StringValue(v.Stomp.Destination),
-				State:            types.StringValue(v.State),
-				Deadletter:       types.BoolValue(v.Deadletter),
-				DeadletterID:     optStringValue(v.DeadletterID),
+			rc := newReconciler(&resp.Diagnostics).forRead()
+			respQueue := buildQueueState(rc, state, v)
+			if resp.Diagnostics.HasError() {
+				return
 			}
+
 			// Sets state to queue values.
-			diags = resp.State.Set(ctx, &respQueues)
+			diags = resp.State.Set(ctx, &respQueue)
 			found = true
 
 			resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_ably_queue_test.go
+++ b/internal/provider/resource_ably_queue_test.go
@@ -106,6 +106,44 @@ resource "ably_queue" "queue0" {
 `, appName, queue.Name, queue.TTL, queue.MaxLength, queue.Region)
 }
 
+func TestAccAblyQueue_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource "ably_queue" "q0" {
+	app_id     = ably_app.app0.id
+	name       = "minimal-queue"
+	ttl        = 60
+	max_length = 10000
+	region     = "us-east-1-a"
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_queue.q0", "id"),
+					resource.TestCheckResourceAttr("ably_queue.q0", "name", "minimal-queue"),
+					resource.TestCheckResourceAttr("ably_queue.q0", "ttl", "60"),
+					resource.TestCheckResourceAttr("ably_queue.q0", "max_length", "10000"),
+					resource.TestCheckResourceAttr("ably_queue.q0", "region", "us-east-1-a"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccAblyQueue_InvalidTTL(t *testing.T) {
 	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_ably_rule_amqp_external_test.go
+++ b/internal/provider/resource_ably_rule_amqp_external_test.go
@@ -133,6 +133,35 @@ func TestAccAblyRuleAMQPExternal(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleAMQPExternal_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_amqp_external", `target = {
+		url                 = "amqps://user:pass@example.com/vhost"
+		routing_key         = "test-key"
+		mandatory_route     = false
+		persistent_messages = false
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_amqp_external.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_amqp_external.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleAMQPExternalConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_amqp_test.go
+++ b/internal/provider/resource_ably_rule_amqp_test.go
@@ -109,6 +109,54 @@ func TestAccAblyRuleAMQP(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleAMQP_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`%s
+resource "ably_app" "app0" {
+	name = %q
+}
+
+resource "ably_queue" "q0" {
+	app_id     = ably_app.app0.id
+	name       = "minimal-amqp-queue"
+	ttl        = 60
+	max_length = 10000
+	region     = "us-east-1-a"
+}
+
+resource "ably_rule_amqp" "rule0" {
+	app_id = ably_app.app0.id
+
+	source = {
+		type = "channel.message"
+	}
+
+	target = {
+		queue_id = ably_queue.q0.id
+	}
+}
+`, tfProvider, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_amqp.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_amqp.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_amqp.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleAMQPConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_azure_function_test.go
+++ b/internal/provider/resource_ably_rule_azure_function_test.go
@@ -112,6 +112,33 @@ func TestAccAblyRuleAzureFunction(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleAzureFunction_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_azure_function", `target = {
+		azure_app_id  = "demo"
+		function_name = "function0"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_azure_function.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_azure_function.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_azure_function.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleAzureFunctionConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_http_cloudflare_worker_test.go
+++ b/internal/provider/resource_ably_rule_http_cloudflare_worker_test.go
@@ -103,6 +103,32 @@ func TestAccAblyRuleCloudflareWorker(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleCloudflareWorker_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_cloudflare_worker", `target = {
+		url = "https://example.com/webhooks"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_cloudflare_worker.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_cloudflare_worker.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_cloudflare_worker.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleCloudflareWorkerConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_http_google_cloud_function_test.go
+++ b/internal/provider/resource_ably_rule_http_google_cloud_function_test.go
@@ -115,6 +115,34 @@ func TestAccAblyRuleGoogleFunction(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleGoogleFunction_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_google_function", `target = {
+		region        = "us-central1"
+		project_id    = "test-project"
+		function_name = "test-function"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_google_function.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_google_function.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_google_function.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleGoogleFunctionConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_http_test.go
+++ b/internal/provider/resource_ably_rule_http_test.go
@@ -181,6 +181,33 @@ resource "ably_rule_http" "rule0" {
 `, appName, ruleStatus, channelFilter, sourceType, requestMode, targetHeaders, targetSigningKeyID, targetURL, targetFormat, enveloped)
 }
 
+func TestAccAblyRuleHTTP_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_http", `target = {
+		url = "https://example.com/webhook"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_http.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_http.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_http.rule0", "request_mode", "single"),
+					resource.TestCheckNoResourceAttr("ably_rule_http.rule0", "source.channel_filter"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccAblyRule_InvalidStatus(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },

--- a/internal/provider/resource_ably_rule_ifttt_test.go
+++ b/internal/provider/resource_ably_rule_ifttt_test.go
@@ -80,6 +80,33 @@ func TestAccAblyRuleIFTTT(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleIFTTT_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_ifttt", `target = {
+		webhook_key = "test-key"
+		event_name  = "test-event"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_ifttt.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_ifttt.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_ifttt.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleIFTTTConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_kafka_test.go
+++ b/internal/provider/resource_ably_rule_kafka_test.go
@@ -107,6 +107,40 @@ func TestAccAblyRuleKafka(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleKafka_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_kafka", `target = {
+		routing_key = "test-key"
+		brokers     = ["broker1.example.com:9092"]
+		auth = {
+			sasl = {
+				mechanism = "plain"
+				username  = "user"
+				password  = "pass"
+			}
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_kafka.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_kafka.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_kafka.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleKafkaConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_kafka_test.go
+++ b/internal/provider/resource_ably_rule_kafka_test.go
@@ -107,11 +107,15 @@ func TestAccAblyRuleKafka(t *testing.T) {
 	})
 }
 
+// The Control API resolves the hostnames in Kafka brokers and Pulsar service
+// URLs (a DNS A lookup, no connection) and rejects a create when one has no
+// record. example.com and example.net are IANA documentation domains that
+// resolve; their subdomains do not.
 func TestAccAblyRuleKafka_Minimal(t *testing.T) {
 	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	config := minimalRuleConfig(appName, "ably_rule_kafka", `target = {
 		routing_key = "test-key"
-		brokers     = ["broker1.example.com:9092"]
+		brokers     = ["example.com:9092"]
 		auth = {
 			sasl = {
 				mechanism = "plain"

--- a/internal/provider/resource_ably_rule_kinesis_test.go
+++ b/internal/provider/resource_ably_rule_kinesis_test.go
@@ -113,6 +113,39 @@ func TestAccAblyRuleKinesis(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleKinesis_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_kinesis", `target = {
+		region         = "us-west-1"
+		stream_name    = "test-stream"
+		partition_key  = "/data"
+		authentication = {
+			mode              = "credentials"
+			access_key_id     = "AKIAIOSFODNN7EXAMPLE"
+			secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_kinesis.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_kinesis.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_kinesis.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleKinesisConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_kinesis_test.go
+++ b/internal/provider/resource_ably_rule_kinesis_test.go
@@ -121,8 +121,8 @@ func TestAccAblyRuleKinesis_Minimal(t *testing.T) {
 		partition_key  = "/data"
 		authentication = {
 			mode              = "credentials"
-			access_key_id     = "AKIAIOSFODNN7EXAMPLE"
-			secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+			access_key_id     = "test-access-key-id"
+			secret_access_key = "test-secret-access-key"
 		}
 	}`)
 

--- a/internal/provider/resource_ably_rule_kinesis_test.go
+++ b/internal/provider/resource_ably_rule_kinesis_test.go
@@ -113,6 +113,39 @@ func TestAccAblyRuleKinesis(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleKinesis_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_kinesis", `target = {
+		region         = "us-west-1"
+		stream_name    = "test-stream"
+		partition_key  = "/data"
+		authentication = {
+			mode              = "credentials"
+			access_key_id     = "test-access-key-id"
+			secret_access_key = "test-secret-access-key"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_kinesis.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_kinesis.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_kinesis.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleKinesisConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_lambda_test.go
+++ b/internal/provider/resource_ably_rule_lambda_test.go
@@ -101,6 +101,38 @@ func TestAccAblyRuleLambda(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleLambda_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_lambda", `target = {
+		region        = "us-west-1"
+		function_name = "test-function"
+		authentication = {
+			mode              = "credentials"
+			access_key_id     = "AKIAIOSFODNN7EXAMPLE"
+			secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_lambda.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_lambda.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_lambda.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleLambdaConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_lambda_test.go
+++ b/internal/provider/resource_ably_rule_lambda_test.go
@@ -101,6 +101,38 @@ func TestAccAblyRuleLambda(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleLambda_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_lambda", `target = {
+		region        = "us-west-1"
+		function_name = "test-function"
+		authentication = {
+			mode              = "credentials"
+			access_key_id     = "test-access-key-id"
+			secret_access_key = "test-secret-access-key"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_lambda.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_lambda.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_lambda.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleLambdaConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_lambda_test.go
+++ b/internal/provider/resource_ably_rule_lambda_test.go
@@ -108,8 +108,8 @@ func TestAccAblyRuleLambda_Minimal(t *testing.T) {
 		function_name = "test-function"
 		authentication = {
 			mode              = "credentials"
-			access_key_id     = "AKIAIOSFODNN7EXAMPLE"
-			secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+			access_key_id     = "test-access-key-id"
+			secret_access_key = "test-secret-access-key"
 		}
 	}`)
 

--- a/internal/provider/resource_ably_rule_pulsar_test.go
+++ b/internal/provider/resource_ably_rule_pulsar_test.go
@@ -105,6 +105,38 @@ func TestAccAblyRulePulsar(t *testing.T) {
 	})
 }
 
+func TestAccAblyRulePulsar_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_pulsar", `target = {
+		routing_key = "test-key"
+		topic       = "my-tenant/my-namespace/my-topic"
+		service_url = "pulsar://pulsar.us-west.example.com:6650/"
+		authentication = {
+			mode  = "token"
+			token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_pulsar.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRulePulsarConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_pulsar_test.go
+++ b/internal/provider/resource_ably_rule_pulsar_test.go
@@ -113,7 +113,7 @@ func TestAccAblyRulePulsar_Minimal(t *testing.T) {
 		service_url = "pulsar://pulsar.us-west.example.com:6650/"
 		authentication = {
 			mode  = "token"
-			token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+			token = "fake-test-token"
 		}
 	}`)
 

--- a/internal/provider/resource_ably_rule_pulsar_test.go
+++ b/internal/provider/resource_ably_rule_pulsar_test.go
@@ -105,6 +105,38 @@ func TestAccAblyRulePulsar(t *testing.T) {
 	})
 }
 
+func TestAccAblyRulePulsar_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_pulsar", `target = {
+		routing_key = "test-key"
+		topic       = "my-tenant/my-namespace/my-topic"
+		service_url = "pulsar://pulsar.us-west.example.com:6650/"
+		authentication = {
+			mode  = "token"
+			token = "fake-test-token"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_pulsar.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRulePulsarConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_pulsar_test.go
+++ b/internal/provider/resource_ably_rule_pulsar_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+// The Control API resolves the hostnames in Kafka brokers and Pulsar service
+// URLs (a DNS A lookup, no connection) and rejects a create when one has no
+// record. example.com and example.net are IANA documentation domains that
+// resolve; their subdomains do not.
 func TestAccAblyRulePulsar(t *testing.T) {
 	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
 	updateAppName := "acc-test-" + appName
@@ -28,7 +32,7 @@ func TestAccAblyRulePulsar(t *testing.T) {
 					"single",
 					"test-key",
 					"my-tenant/my-namespace/my-topic",
-					"pulsar://pulsar.us-west.example.com:6650/",
+					"pulsar://example.com:6650/",
 					"true",
 					"json",
 					"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
@@ -43,7 +47,7 @@ func TestAccAblyRulePulsar(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "request_mode", "single"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.routing_key", "test-key"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.topic", "my-tenant/my-namespace/my-topic"),
-					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.service_url", "pulsar://pulsar.us-west.example.com:6650/"),
+					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.service_url", "pulsar://example.com:6650/"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.enveloped", "true"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.format", "json"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.authentication.mode", "token"),
@@ -78,7 +82,7 @@ func TestAccAblyRulePulsar(t *testing.T) {
 					"single",
 					"test-key1",
 					"my-tenant/my-namespace/my-topic1",
-					"pulsar://pulsar.us-east.example.com:6650/",
+					"pulsar://example.net:6650/",
 					"false",
 					"msgpack",
 					"YWxnOkhTNTEyIHR5cDpKV1QK",
@@ -93,7 +97,7 @@ func TestAccAblyRulePulsar(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "request_mode", "single"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.routing_key", "test-key1"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.topic", "my-tenant/my-namespace/my-topic1"),
-					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.service_url", "pulsar://pulsar.us-east.example.com:6650/"),
+					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.service_url", "pulsar://example.net:6650/"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.enveloped", "false"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.format", "msgpack"),
 					resource.TestCheckResourceAttr("ably_rule_pulsar.rule0", "target.authentication.mode", "token"),
@@ -110,7 +114,7 @@ func TestAccAblyRulePulsar_Minimal(t *testing.T) {
 	config := minimalRuleConfig(appName, "ably_rule_pulsar", `target = {
 		routing_key = "test-key"
 		topic       = "my-tenant/my-namespace/my-topic"
-		service_url = "pulsar://pulsar.us-west.example.com:6650/"
+		service_url = "pulsar://example.com:6650/"
 		authentication = {
 			mode  = "token"
 			token = "fake-test-token"

--- a/internal/provider/resource_ably_rule_sqs_test.go
+++ b/internal/provider/resource_ably_rule_sqs_test.go
@@ -106,6 +106,40 @@ func TestAccAblyRuleSqs(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleSqs_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_sqs", `target = {
+		region         = "us-west-1"
+		aws_account_id = "123456789012"
+		queue_name     = "test-queue"
+		format         = "json"
+		authentication = {
+			mode              = "credentials"
+			access_key_id     = "AKIAIOSFODNN7EXAMPLE"
+			secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_sqs.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_sqs.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_sqs.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleSqsConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_sqs_test.go
+++ b/internal/provider/resource_ably_rule_sqs_test.go
@@ -106,6 +106,40 @@ func TestAccAblyRuleSqs(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleSqs_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_sqs", `target = {
+		region         = "us-west-1"
+		aws_account_id = "123456789012"
+		queue_name     = "test-queue"
+		format         = "json"
+		authentication = {
+			mode              = "credentials"
+			access_key_id     = "test-access-key-id"
+			secret_access_key = "test-secret-access-key"
+		}
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_sqs.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_sqs.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_sqs.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleSqsConfig(
 	appName string,

--- a/internal/provider/resource_ably_rule_sqs_test.go
+++ b/internal/provider/resource_ably_rule_sqs_test.go
@@ -115,8 +115,8 @@ func TestAccAblyRuleSqs_Minimal(t *testing.T) {
 		format         = "json"
 		authentication = {
 			mode              = "credentials"
-			access_key_id     = "AKIAIOSFODNN7EXAMPLE"
-			secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+			access_key_id     = "test-access-key-id"
+			secret_access_key = "test-secret-access-key"
 		}
 	}`)
 

--- a/internal/provider/resource_ably_rule_zapier_test.go
+++ b/internal/provider/resource_ably_rule_zapier_test.go
@@ -103,6 +103,32 @@ func TestAccAblyRuleZapier(t *testing.T) {
 	})
 }
 
+func TestAccAblyRuleZapier_Minimal(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := minimalRuleConfig(appName, "ably_rule_zapier", `target = {
+		url = "https://hooks.zapier.com/hooks/catch/000000/aaaaa"
+	}`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ably_rule_zapier.rule0", "id"),
+					resource.TestCheckResourceAttr("ably_rule_zapier.rule0", "status", "enabled"),
+					resource.TestCheckResourceAttr("ably_rule_zapier.rule0", "request_mode", "single"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 // Function with inline HCL to provision an ably_app resource
 func testAccAblyRuleZapierConfig(
 	appName string,

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -321,7 +321,7 @@ func GetRequestMode(plan AblyRule) string {
 
 // GetAwsAuth converts AWS authentication from control SDK format to terraform format.
 // Using plan to fill in values that the api does not return.
-func GetAwsAuth(auth control.AWSAuthentication, plan *AblyRule) AwsAuth {
+func GetAwsAuth(rc *reconciler, auth control.AWSAuthentication, plan *AblyRule) AwsAuth {
 	var planAuth AwsAuth
 
 	switch p := plan.Target.(type) {
@@ -339,25 +339,29 @@ func GetAwsAuth(auth control.AWSAuthentication, plan *AblyRule) AwsAuth {
 		}
 	}
 
-	var respAwsAuth AwsAuth
+	// The API returns different fields depending on auth mode.
+	// Fields not relevant to the current mode are null in the response,
+	// so we pass types.StringNull() as the output for those — reconcile
+	// case 4 (both empty → null) or case 2 (echo plan) handles them.
+	var modeOutput, keyOutput, secretOutput, arnOutput types.String
+	modeOutput = types.StringValue(auth.AuthenticationMode)
 	switch control.AWSAuthMode(auth.AuthenticationMode) {
 	case control.AWSAuthModeCredentials:
-		respAwsAuth = AwsAuth{
-			AuthenticationMode: types.StringValue(auth.AuthenticationMode),
-			AccessKeyId:        types.StringValue(auth.AccessKeyID),
-			SecretAccessKey:    planAuth.SecretAccessKey,
-			RoleArn:            types.StringNull(),
-		}
+		keyOutput = types.StringValue(auth.AccessKeyID)
+		secretOutput = types.StringNull() // write-only, never returned
+		arnOutput = types.StringNull()
 	case control.AWSAuthModeAssumeRole:
-		respAwsAuth = AwsAuth{
-			AuthenticationMode: types.StringValue(auth.AuthenticationMode),
-			RoleArn:            types.StringValue(auth.AssumeRoleArn),
-			AccessKeyId:        types.StringNull(),
-			SecretAccessKey:    types.StringNull(),
-		}
+		keyOutput = types.StringNull()
+		secretOutput = types.StringNull()
+		arnOutput = types.StringValue(auth.AssumeRoleArn)
 	}
 
-	return respAwsAuth
+	return AwsAuth{
+		AuthenticationMode: rc.str("target.authentication.mode", planAuth.AuthenticationMode, modeOutput, false),
+		AccessKeyId:        rc.str("target.authentication.access_key_id", planAuth.AccessKeyId, keyOutput, false),
+		SecretAccessKey:    rc.str("target.authentication.secret_access_key", planAuth.SecretAccessKey, secretOutput, false),
+		RoleArn:            rc.str("target.authentication.role_arn", planAuth.RoleArn, arnOutput, false),
+	}
 }
 
 // unmarshalTarget JSON-marshals the generic target from RuleResponse and unmarshals into a typed struct.
@@ -387,8 +391,13 @@ func ToHeaders(headers []control.RuleHeader) []AblyRuleHeaders {
 // GetRuleResponse maps response body to resource schema attributes.
 // Using plan to fill in values that the api does not return.
 // Returns (AblyRule, diag.Diagnostics) so callers can check for unmarshal errors.
-func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, diag.Diagnostics) {
+func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule, reading bool) (AblyRule, diag.Diagnostics) {
 	var diags diag.Diagnostics
+	rc := newReconciler(&diags)
+	if reading {
+		rc.forRead()
+	}
+
 	var respTarget any
 
 	switch ablyRule.RuleType {
@@ -398,13 +407,17 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/kinesis target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
+		var pt *AblyRuleTargetKinesis
+		if p, ok := plan.Target.(*AblyRuleTargetKinesis); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetKinesis{
-			Region:       types.StringValue(target.Region),
-			StreamName:   types.StringValue(target.StreamName),
-			PartitionKey: types.StringValue(target.PartitionKey),
-			AwsAuth:      GetAwsAuth(target.Authentication, plan),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
-			Format:       types.StringValue(target.Format),
+			Region:       rc.str("target.region", planStr(pt, func(t *AblyRuleTargetKinesis) types.String { return t.Region }), types.StringValue(target.Region), false),
+			StreamName:   rc.str("target.stream_name", planStr(pt, func(t *AblyRuleTargetKinesis) types.String { return t.StreamName }), types.StringValue(target.StreamName), false),
+			PartitionKey: rc.str("target.partition_key", planStr(pt, func(t *AblyRuleTargetKinesis) types.String { return t.PartitionKey }), types.StringValue(target.PartitionKey), false),
+			AwsAuth:      GetAwsAuth(rc, target.Authentication, plan),
+			Enveloped:    rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetKinesis) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:       rc.str("target.format", planStr(pt, func(t *AblyRuleTargetKinesis) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "aws/sqs":
 		target, err := unmarshalTarget[control.AWSSQSTarget](ablyRule.Target)
@@ -412,13 +425,17 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/sqs target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
+		var pt *AblyRuleTargetSqs
+		if p, ok := plan.Target.(*AblyRuleTargetSqs); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetSqs{
-			Region:       types.StringValue(target.Region),
-			AwsAccountID: types.StringValue(target.AWSAccountID),
-			QueueName:    types.StringValue(target.QueueName),
-			AwsAuth:      GetAwsAuth(target.Authentication, plan),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
-			Format:       types.StringValue(target.Format),
+			Region:       rc.str("target.region", planStr(pt, func(t *AblyRuleTargetSqs) types.String { return t.Region }), types.StringValue(target.Region), false),
+			AwsAccountID: rc.str("target.aws_account_id", planStr(pt, func(t *AblyRuleTargetSqs) types.String { return t.AwsAccountID }), types.StringValue(target.AWSAccountID), false),
+			QueueName:    rc.str("target.queue_name", planStr(pt, func(t *AblyRuleTargetSqs) types.String { return t.QueueName }), types.StringValue(target.QueueName), false),
+			AwsAuth:      GetAwsAuth(rc, target.Authentication, plan),
+			Enveloped:    rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetSqs) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:       rc.str("target.format", planStr(pt, func(t *AblyRuleTargetSqs) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "aws/lambda":
 		target, err := unmarshalTarget[control.AWSLambdaTarget](ablyRule.Target)
@@ -426,11 +443,15 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/lambda target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
+		var pt *AblyRuleTargetLambda
+		if p, ok := plan.Target.(*AblyRuleTargetLambda); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetLambda{
-			Region:       types.StringValue(target.Region),
-			FunctionName: types.StringValue(target.FunctionName),
-			AwsAuth:      GetAwsAuth(target.Authentication, plan),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
+			Region:       rc.str("target.region", planStr(pt, func(t *AblyRuleTargetLambda) types.String { return t.Region }), types.StringValue(target.Region), false),
+			FunctionName: rc.str("target.function_name", planStr(pt, func(t *AblyRuleTargetLambda) types.String { return t.FunctionName }), types.StringValue(target.FunctionName), false),
+			AwsAuth:      GetAwsAuth(rc, target.Authentication, plan),
+			Enveloped:    rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetLambda) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
 		}
 	case "http/zapier":
 		target, err := unmarshalTarget[control.ZapierRuleTarget](ablyRule.Target)
@@ -438,11 +459,14 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/zapier target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
+		var pt *AblyRuleTargetZapier
+		if p, ok := plan.Target.(*AblyRuleTargetZapier); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetZapier{
-			Url:          types.StringValue(target.URL),
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Headers:      headers,
+			Url:          rc.str("target.url", planStr(pt, func(t *AblyRuleTargetZapier) types.String { return t.Url }), types.StringValue(target.URL), false),
+			SigningKeyId: rc.str("target.signing_key_id", planStr(pt, func(t *AblyRuleTargetZapier) types.String { return t.SigningKeyId }), optStringValue(target.SigningKeyID), true),
+			Headers:      rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetZapier) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
 		}
 	case "http/cloudflare-worker":
 		target, err := unmarshalTarget[control.CloudflareWorkerRuleTarget](ablyRule.Target)
@@ -450,11 +474,14 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/cloudflare-worker target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
+		var pt *AblyRuleTargetCloudflareWorker
+		if p, ok := plan.Target.(*AblyRuleTargetCloudflareWorker); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetCloudflareWorker{
-			Url:          types.StringValue(target.URL),
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Headers:      headers,
+			Url:          rc.str("target.url", planStr(pt, func(t *AblyRuleTargetCloudflareWorker) types.String { return t.Url }), types.StringValue(target.URL), false),
+			SigningKeyId: rc.str("target.signing_key_id", planStr(pt, func(t *AblyRuleTargetCloudflareWorker) types.String { return t.SigningKeyId }), optStringValue(target.SigningKeyID), true),
+			Headers:      rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetCloudflareWorker) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
 		}
 	case "pulsar":
 		target, err := unmarshalTarget[control.PulsarRuleTarget](ablyRule.Target)
@@ -462,12 +489,9 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal pulsar target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		// TlsTrustCerts is write-only in the API (accepted on create/update but
-		// never returned on read), so preserve whatever the user configured in
-		// state rather than overwriting it with nil from the API response.
-		var tlsTrustCerts []types.String
-		if p, ok := plan.Target.(*AblyRuleTargetPulsar); ok && p != nil {
-			tlsTrustCerts = p.TlsTrustCerts
+		var pt *AblyRuleTargetPulsar
+		if p, ok := plan.Target.(*AblyRuleTargetPulsar); ok {
+			pt = p
 		}
 		authMode := ""
 		authToken := ""
@@ -476,16 +500,16 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			authToken = target.Authentication.Token
 		}
 		respTarget = &AblyRuleTargetPulsar{
-			RoutingKey:    types.StringValue(target.RoutingKey),
-			Topic:         types.StringValue(target.Topic),
-			ServiceURL:    types.StringValue(target.ServiceURL),
-			TlsTrustCerts: tlsTrustCerts,
+			RoutingKey:    rc.str("target.routing_key", planStr(pt, func(t *AblyRuleTargetPulsar) types.String { return t.RoutingKey }), types.StringValue(target.RoutingKey), false),
+			Topic:         rc.str("target.topic", planStr(pt, func(t *AblyRuleTargetPulsar) types.String { return t.Topic }), types.StringValue(target.Topic), false),
+			ServiceURL:    rc.str("target.service_url", planStr(pt, func(t *AblyRuleTargetPulsar) types.String { return t.ServiceURL }), types.StringValue(target.ServiceURL), false),
+			TlsTrustCerts: rcSlice(rc, "target.tls_trust_certs", planSlice(pt, func(t *AblyRuleTargetPulsar) []types.String { return t.TlsTrustCerts }), toTypedStringSlice(target.TLSTrustCerts), false),
 			Authentication: PulsarAuthentication{
-				Mode:  types.StringValue(authMode),
-				Token: types.StringValue(authToken),
+				Mode:  rc.str("target.authentication.mode", planStr(pt, func(t *AblyRuleTargetPulsar) types.String { return t.Authentication.Mode }), types.StringValue(authMode), false),
+				Token: rc.str("target.authentication.token", planStr(pt, func(t *AblyRuleTargetPulsar) types.String { return t.Authentication.Token }), types.StringValue(authToken), false),
 			},
-			Enveloped: types.BoolValue(deref(target.Enveloped)),
-			Format:    types.StringValue(target.Format),
+			Enveloped: rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetPulsar) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:    rc.str("target.format", planStr(pt, func(t *AblyRuleTargetPulsar) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "http/ifttt":
 		target, err := unmarshalTarget[control.IFTTTRuleTarget](ablyRule.Target)
@@ -493,9 +517,13 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/ifttt target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
+		var pt *AblyRuleTargetIFTTT
+		if p, ok := plan.Target.(*AblyRuleTargetIFTTT); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetIFTTT{
-			EventName:  types.StringValue(target.EventName),
-			WebhookKey: types.StringValue(target.WebhookKey),
+			EventName:  rc.str("target.event_name", planStr(pt, func(t *AblyRuleTargetIFTTT) types.String { return t.EventName }), types.StringValue(target.EventName), false),
+			WebhookKey: rc.str("target.webhook_key", planStr(pt, func(t *AblyRuleTargetIFTTT) types.String { return t.WebhookKey }), types.StringValue(target.WebhookKey), false),
 		}
 	case "http/google-cloud-function":
 		target, err := unmarshalTarget[control.GoogleCloudFunctionRuleTarget](ablyRule.Target)
@@ -503,15 +531,18 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/google-cloud-function target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
+		var pt *AblyRuleTargetGoogleFunction
+		if p, ok := plan.Target.(*AblyRuleTargetGoogleFunction); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetGoogleFunction{
-			Region:       types.StringValue(target.Region),
-			ProjectID:    types.StringValue(target.ProjectID),
-			FunctionName: types.StringValue(target.FunctionName),
-			Headers:      headers,
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
-			Format:       types.StringValue(target.Format),
+			Region:       rc.str("target.region", planStr(pt, func(t *AblyRuleTargetGoogleFunction) types.String { return t.Region }), types.StringValue(target.Region), false),
+			ProjectID:    rc.str("target.project_id", planStr(pt, func(t *AblyRuleTargetGoogleFunction) types.String { return t.ProjectID }), types.StringValue(target.ProjectID), false),
+			FunctionName: rc.str("target.function_name", planStr(pt, func(t *AblyRuleTargetGoogleFunction) types.String { return t.FunctionName }), types.StringValue(target.FunctionName), false),
+			Headers:      rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetGoogleFunction) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
+			SigningKeyId: rc.str("target.signing_key_id", planStr(pt, func(t *AblyRuleTargetGoogleFunction) types.String { return t.SigningKeyId }), optStringValue(target.SigningKeyID), true),
+			Enveloped:    rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetGoogleFunction) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:       rc.str("target.format", planStr(pt, func(t *AblyRuleTargetGoogleFunction) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "http/azure-function":
 		target, err := unmarshalTarget[control.AzureFunctionRuleTarget](ablyRule.Target)
@@ -519,14 +550,17 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/azure-function target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
+		var pt *AblyRuleTargetAzureFunction
+		if p, ok := plan.Target.(*AblyRuleTargetAzureFunction); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetAzureFunction{
-			AzureAppID:        types.StringValue(target.AzureAppID),
-			AzureFunctionName: types.StringValue(target.AzureFunctionName),
-			Headers:           headers,
-			SigningKeyID:      optStringValue(target.SigningKeyID),
-			Enveloped:         types.BoolValue(deref(target.Enveloped)),
-			Format:            types.StringValue(target.Format),
+			AzureAppID:        rc.str("target.azure_app_id", planStr(pt, func(t *AblyRuleTargetAzureFunction) types.String { return t.AzureAppID }), types.StringValue(target.AzureAppID), false),
+			AzureFunctionName: rc.str("target.function_name", planStr(pt, func(t *AblyRuleTargetAzureFunction) types.String { return t.AzureFunctionName }), types.StringValue(target.AzureFunctionName), false),
+			Headers:           rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetAzureFunction) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
+			SigningKeyID:      rc.str("target.signing_key_id", planStr(pt, func(t *AblyRuleTargetAzureFunction) types.String { return t.SigningKeyID }), optStringValue(target.SigningKeyID), true),
+			Enveloped:         rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetAzureFunction) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:            rc.str("target.format", planStr(pt, func(t *AblyRuleTargetAzureFunction) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "http":
 		target, err := unmarshalTarget[control.HTTPRuleTarget](ablyRule.Target)
@@ -534,19 +568,26 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
+		var pt *AblyRuleTargetHTTP
+		if p, ok := plan.Target.(*AblyRuleTargetHTTP); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetHTTP{
-			Url:          types.StringValue(target.URL),
-			Headers:      headers,
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Format:       types.StringValue(target.Format),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
+			Url:          rc.str("target.url", planStr(pt, func(t *AblyRuleTargetHTTP) types.String { return t.Url }), types.StringValue(target.URL), false),
+			Headers:      rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetHTTP) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
+			SigningKeyId: rc.str("target.signing_key_id", planStr(pt, func(t *AblyRuleTargetHTTP) types.String { return t.SigningKeyId }), optStringValue(target.SigningKeyID), true),
+			Format:       rc.str("target.format", planStr(pt, func(t *AblyRuleTargetHTTP) types.String { return t.Format }), types.StringValue(target.Format), true),
+			Enveloped:    rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetHTTP) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
 		}
 	case "kafka":
 		target, err := unmarshalTarget[control.KafkaRuleTarget](ablyRule.Target)
 		if err != nil {
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal kafka target: %s", err.Error()))
 			return AblyRule{}, diags
+		}
+		var pt *AblyRuleTargetKafka
+		if p, ok := plan.Target.(*AblyRuleTargetKafka); ok {
+			pt = p
 		}
 		saslMechanism := ""
 		saslUsername := ""
@@ -557,17 +598,17 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			saslPassword = target.Auth.SASL.Password
 		}
 		respTarget = &AblyRuleTargetKafka{
-			RoutingKey: types.StringValue(target.RoutingKey),
-			Brokers:    toTypedStringSlice(target.Brokers),
+			RoutingKey: rc.str("target.routing_key", planStr(pt, func(t *AblyRuleTargetKafka) types.String { return t.RoutingKey }), types.StringValue(target.RoutingKey), false),
+			Brokers:    rcSlice(rc, "target.brokers", planSlice(pt, func(t *AblyRuleTargetKafka) []types.String { return t.Brokers }), toTypedStringSlice(target.Brokers), false),
 			KafkaAuthentication: KafkaAuthentication{
 				Sasl{
-					Mechanism: types.StringValue(saslMechanism),
-					Username:  types.StringValue(saslUsername),
-					Password:  types.StringValue(saslPassword),
+					Mechanism: rc.str("target.auth.sasl.mechanism", planStr(pt, func(t *AblyRuleTargetKafka) types.String { return t.KafkaAuthentication.Sasl.Mechanism }), types.StringValue(saslMechanism), false),
+					Username:  rc.str("target.auth.sasl.username", planStr(pt, func(t *AblyRuleTargetKafka) types.String { return t.KafkaAuthentication.Sasl.Username }), types.StringValue(saslUsername), false),
+					Password:  rc.str("target.auth.sasl.password", planStr(pt, func(t *AblyRuleTargetKafka) types.String { return t.KafkaAuthentication.Sasl.Password }), types.StringValue(saslPassword), false),
 				},
 			},
-			Enveloped: types.BoolValue(deref(target.Enveloped)),
-			Format:    types.StringValue(target.Format),
+			Enveloped: rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetKafka) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:    rc.str("target.format", planStr(pt, func(t *AblyRuleTargetKafka) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "amqp":
 		target, err := unmarshalTarget[control.AMQPRuleTarget](ablyRule.Target)
@@ -575,12 +616,15 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal amqp target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
+		var pt *AblyRuleTargetAMQP
+		if p, ok := plan.Target.(*AblyRuleTargetAMQP); ok {
+			pt = p
+		}
 		respTarget = &AblyRuleTargetAMQP{
-			QueueID:   types.StringValue(target.QueueID),
-			Headers:   headers,
-			Enveloped: types.BoolValue(deref(target.Enveloped)),
-			Format:    types.StringValue(target.Format),
+			QueueID:   rc.str("target.queue_id", planStr(pt, func(t *AblyRuleTargetAMQP) types.String { return t.QueueID }), types.StringValue(target.QueueID), false),
+			Headers:   rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetAMQP) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
+			Enveloped: rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetAMQP) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:    rc.str("target.format", planStr(pt, func(t *AblyRuleTargetAMQP) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	case "amqp/external":
 		target, err := unmarshalTarget[control.AMQPExternalRuleTarget](ablyRule.Target)
@@ -588,43 +632,20 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal amqp/external target: %s", err.Error()))
 			return AblyRule{}, diags
 		}
-		headers := ToHeaders(target.Headers)
-
-		// Several target fields are not required in the API response and may
-		// be omitted. When the plan provided values for these fields, preserve
-		// them so Terraform doesn't see a diff (the target block contains the
-		// sensitive "url" field, so ANY field mismatch triggers the opaque
-		// "inconsistent values for sensitive attribute" error).
-		url := types.StringValue(target.URL)
-		exchange := types.StringNull()
-		if target.Exchange != "" {
-			exchange = types.StringValue(target.Exchange)
-		}
-		ttl := types.Int64Null()
-		if target.MessageTTL != nil && *target.MessageTTL != 0 {
-			ttl = types.Int64Value(int64(*target.MessageTTL))
-		}
-		if p, ok := plan.Target.(*AblyRuleTargetAMQPExternal); ok && p != nil {
-			if !p.Url.IsNull() {
-				url = p.Url
-			}
-			if target.Exchange == "" {
-				exchange = p.Exchange
-			}
-			if ttl.IsNull() && !p.MessageTtl.IsNull() {
-				ttl = p.MessageTtl
-			}
+		var pt *AblyRuleTargetAMQPExternal
+		if p, ok := plan.Target.(*AblyRuleTargetAMQPExternal); ok {
+			pt = p
 		}
 		respTarget = &AblyRuleTargetAMQPExternal{
-			Url:                url,
-			RoutingKey:         types.StringValue(target.RoutingKey),
-			Exchange:           exchange,
-			MandatoryRoute:     types.BoolValue(deref(target.MandatoryRoute)),
-			PersistentMessages: types.BoolValue(deref(target.PersistentMessages)),
-			MessageTtl:         ttl,
-			Headers:            headers,
-			Enveloped:          types.BoolValue(deref(target.Enveloped)),
-			Format:             types.StringValue(target.Format),
+			Url:                rc.str("target.url", planStr(pt, func(t *AblyRuleTargetAMQPExternal) types.String { return t.Url }), types.StringValue(target.URL), false),
+			RoutingKey:         rc.str("target.routing_key", planStr(pt, func(t *AblyRuleTargetAMQPExternal) types.String { return t.RoutingKey }), types.StringValue(target.RoutingKey), false),
+			Exchange:           rc.str("target.exchange", planStr(pt, func(t *AblyRuleTargetAMQPExternal) types.String { return t.Exchange }), optStringValue(&target.Exchange), false),
+			MandatoryRoute:     rc.boolean("target.mandatory_route", planBool(pt, func(t *AblyRuleTargetAMQPExternal) types.Bool { return t.MandatoryRoute }), optBoolValue(target.MandatoryRoute), false),
+			PersistentMessages: rc.boolean("target.persistent_messages", planBool(pt, func(t *AblyRuleTargetAMQPExternal) types.Bool { return t.PersistentMessages }), optBoolValue(target.PersistentMessages), false),
+			MessageTtl:         rc.int64val("target.message_ttl", planInt64(pt, func(t *AblyRuleTargetAMQPExternal) types.Int64 { return t.MessageTtl }), optIntFromIntPtr(target.MessageTTL), false),
+			Headers:            rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetAMQPExternal) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
+			Enveloped:          rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetAMQPExternal) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
+			Format:             rc.str("target.format", planStr(pt, func(t *AblyRuleTargetAMQPExternal) types.String { return t.Format }), types.StringValue(target.Format), true),
 		}
 	default:
 		diags.AddError(
@@ -632,6 +653,11 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			fmt.Sprintf("Received unrecognized rule type from API: %q", ablyRule.RuleType),
 		)
 		return AblyRule{}, diags
+	}
+
+	var planSource *AblyRuleSource
+	if plan.Source != nil {
+		planSource = plan.Source
 	}
 
 	channelFilter := types.StringNull()
@@ -645,17 +671,16 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 	}
 
 	respSource := AblyRuleSource{
-		ChannelFilter: channelFilter,
-		Type:          types.StringValue(sourceType),
+		ChannelFilter: rc.str("source.channel_filter", planStr(planSource, func(s *AblyRuleSource) types.String { return s.ChannelFilter }), channelFilter, false),
+		Type:          rc.str("source.type", planStr(planSource, func(s *AblyRuleSource) types.String { return s.Type }), types.StringValue(sourceType), false),
 	}
-
 	respRule := AblyRule{
-		ID:          types.StringValue(ablyRule.ID),
-		AppID:       types.StringValue(ablyRule.AppID),
-		Status:      types.StringValue(ablyRule.Status),
+		ID:          rc.str("id", plan.ID, types.StringValue(ablyRule.ID), true),
+		AppID:       rc.str("app_id", plan.AppID, types.StringValue(ablyRule.AppID), false),
+		Status:      rc.str("status", plan.Status, types.StringValue(ablyRule.Status), true),
 		Source:      &respSource,
 		Target:      respTarget,
-		RequestMode: types.StringValue(ablyRule.RequestMode),
+		RequestMode: rc.str("request_mode", plan.RequestMode, types.StringValue(ablyRule.RequestMode), true),
 	}
 
 	return respRule, diags
@@ -835,7 +860,7 @@ func CreateRule[T any](r Rule, ctx context.Context, req resource.CreateRequest, 
 		return
 	}
 
-	responseValues, respDiags := GetRuleResponse(&rule, &plan)
+	responseValues, respDiags := GetRuleResponse(&rule, &plan, false)
 	resp.Diagnostics.Append(respDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -881,7 +906,7 @@ func ReadRule[T any](r Rule, ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	responseValues, respDiags := GetRuleResponse(&rule, &state)
+	responseValues, respDiags := GetRuleResponse(&rule, &state, true)
 	resp.Diagnostics.Append(respDiags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -930,7 +955,7 @@ func UpdateRule[T any](r Rule, ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	responseValues, respDiags := GetRuleResponse(&rule, &plan)
+	responseValues, respDiags := GetRuleResponse(&rule, &plan, false)
 	resp.Diagnostics.Append(respDiags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -658,7 +658,7 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule, reading boo
 			Exchange:           rc.str("target.exchange", planStr(pt, func(t *AblyRuleTargetAMQPExternal) types.String { return t.Exchange }), optStringValue(&target.Exchange), false),
 			MandatoryRoute:     rc.boolean("target.mandatory_route", planBool(pt, func(t *AblyRuleTargetAMQPExternal) types.Bool { return t.MandatoryRoute }), optBoolValue(target.MandatoryRoute), false),
 			PersistentMessages: rc.boolean("target.persistent_messages", planBool(pt, func(t *AblyRuleTargetAMQPExternal) types.Bool { return t.PersistentMessages }), optBoolValue(target.PersistentMessages), false),
-			MessageTtl:         rc.int64val("target.message_ttl", planInt64(pt, func(t *AblyRuleTargetAMQPExternal) types.Int64 { return t.MessageTtl }), optIntFromIntPtr(target.MessageTTL), false),
+			MessageTtl:         rc.int64val("target.message_ttl", planInt64(pt, func(t *AblyRuleTargetAMQPExternal) types.Int64 { return t.MessageTtl }), optIntValue(target.MessageTTL), false),
 			Headers:            rcSlice(rc, "target.headers", planSlice(pt, func(t *AblyRuleTargetAMQPExternal) []AblyRuleHeaders { return t.Headers }), ToHeaders(target.Headers), false),
 			Enveloped:          rc.boolean("target.enveloped", planBool(pt, func(t *AblyRuleTargetAMQPExternal) types.Bool { return t.Enveloped }), optBoolValue(target.Enveloped), true),
 			Format:             rc.str("target.format", planStr(pt, func(t *AblyRuleTargetAMQPExternal) types.String { return t.Format }), types.StringValue(target.Format), true),

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -339,6 +339,22 @@ func GetAwsAuth(rc *reconciler, auth control.AWSAuthentication, plan *AblyRule) 
 		}
 	}
 
+	// On Read, an out-of-band switch of authentication mode means fields from
+	// the previously active mode no longer apply. Reconciling them against
+	// prior state would echo the stale values (input non-empty, output empty →
+	// echo input), leaving both modes' fields in state at once — drop them.
+	if rc.reading && auth.AuthenticationMode != "" &&
+		!planAuth.AuthenticationMode.IsNull() && !planAuth.AuthenticationMode.IsUnknown() &&
+		planAuth.AuthenticationMode.ValueString() != auth.AuthenticationMode {
+		switch control.AWSAuthMode(auth.AuthenticationMode) {
+		case control.AWSAuthModeCredentials:
+			planAuth.RoleArn = types.StringNull()
+		case control.AWSAuthModeAssumeRole:
+			planAuth.AccessKeyId = types.StringNull()
+			planAuth.SecretAccessKey = types.StringNull()
+		}
+	}
+
 	// The API returns different fields depending on auth mode.
 	// Fields not relevant to the current mode are null in the response,
 	// so we pass types.StringNull() as the output for those — reconcile

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -695,7 +695,6 @@ func GetRuleSchema(target map[string]schema.Attribute, markdownDescription strin
 				Description: "This is Single Request mode or Batch Request mode. Single Request mode sends each event separately to the endpoint specified by the rule",
 				PlanModifiers: []planmodifier.String{
 					DefaultStringAttribute(types.StringValue("single")),
-					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
 					stringvalidator.OneOf("single", "batch"),

--- a/internal/provider/rules.go
+++ b/internal/provider/rules.go
@@ -321,7 +321,7 @@ func GetRequestMode(plan AblyRule) string {
 
 // GetAwsAuth converts AWS authentication from control SDK format to terraform format.
 // Using plan to fill in values that the api does not return.
-func GetAwsAuth(auth control.AWSAuthentication, plan *AblyRule) AwsAuth {
+func GetAwsAuth(rc *reconciler, auth control.AWSAuthentication, plan *AblyRule) AwsAuth {
 	var planAuth AwsAuth
 
 	switch p := plan.Target.(type) {
@@ -339,25 +339,45 @@ func GetAwsAuth(auth control.AWSAuthentication, plan *AblyRule) AwsAuth {
 		}
 	}
 
-	var respAwsAuth AwsAuth
-	switch control.AWSAuthMode(auth.AuthenticationMode) {
-	case control.AWSAuthModeCredentials:
-		respAwsAuth = AwsAuth{
-			AuthenticationMode: types.StringValue(auth.AuthenticationMode),
-			AccessKeyId:        types.StringValue(auth.AccessKeyID),
-			SecretAccessKey:    planAuth.SecretAccessKey,
-			RoleArn:            types.StringNull(),
-		}
-	case control.AWSAuthModeAssumeRole:
-		respAwsAuth = AwsAuth{
-			AuthenticationMode: types.StringValue(auth.AuthenticationMode),
-			RoleArn:            types.StringValue(auth.AssumeRoleArn),
-			AccessKeyId:        types.StringNull(),
-			SecretAccessKey:    types.StringNull(),
+	// On Read, an out-of-band switch of authentication mode means fields from
+	// the previously active mode no longer apply. Reconciling them against
+	// prior state would echo the stale values (input non-empty, output empty →
+	// echo input), leaving both modes' fields in state at once — drop them.
+	if rc.reading && auth.AuthenticationMode != "" &&
+		!planAuth.AuthenticationMode.IsNull() && !planAuth.AuthenticationMode.IsUnknown() &&
+		planAuth.AuthenticationMode.ValueString() != auth.AuthenticationMode {
+		switch control.AWSAuthMode(auth.AuthenticationMode) {
+		case control.AWSAuthModeCredentials:
+			planAuth.RoleArn = types.StringNull()
+		case control.AWSAuthModeAssumeRole:
+			planAuth.AccessKeyId = types.StringNull()
+			planAuth.SecretAccessKey = types.StringNull()
 		}
 	}
 
-	return respAwsAuth
+	// The API returns different fields depending on auth mode.
+	// Fields not relevant to the current mode are null in the response,
+	// so we pass types.StringNull() as the output for those — reconcile
+	// case 4 (both empty → null) or case 2 (echo plan) handles them.
+	var modeOutput, keyOutput, secretOutput, arnOutput types.String
+	modeOutput = types.StringValue(auth.AuthenticationMode)
+	switch control.AWSAuthMode(auth.AuthenticationMode) {
+	case control.AWSAuthModeCredentials:
+		keyOutput = types.StringValue(auth.AccessKeyID)
+		secretOutput = types.StringNull() // write-only, never returned
+		arnOutput = types.StringNull()
+	case control.AWSAuthModeAssumeRole:
+		keyOutput = types.StringNull()
+		secretOutput = types.StringNull()
+		arnOutput = types.StringValue(auth.AssumeRoleArn)
+	}
+
+	return AwsAuth{
+		AuthenticationMode: rcVal(rc, "target.authentication.mode", planAuth.AuthenticationMode, modeOutput, false),
+		AccessKeyId:        rcVal(rc, "target.authentication.access_key_id", planAuth.AccessKeyId, keyOutput, false),
+		SecretAccessKey:    rcVal(rc, "target.authentication.secret_access_key", planAuth.SecretAccessKey, secretOutput, false),
+		RoleArn:            rcVal(rc, "target.authentication.role_arn", planAuth.RoleArn, arnOutput, false),
+	}
 }
 
 // unmarshalTarget JSON-marshals the generic target from RuleResponse and unmarshals into a typed struct.
@@ -384,91 +404,89 @@ func ToHeaders(headers []control.RuleHeader) []AblyRuleHeaders {
 	return respHeaders
 }
 
-// GetRuleResponse maps response body to resource schema attributes.
-// Using plan to fill in values that the api does not return.
-// Returns (AblyRule, diag.Diagnostics) so callers can check for unmarshal errors.
-func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, diag.Diagnostics) {
-	var diags diag.Diagnostics
+// GetRuleResponse maps a rule response onto the resource schema, reconciling
+// each field against plan (Create/Update) or prior state (Read, via a
+// reconciler in read mode). Unmarshal and reconciliation errors are reported
+// through the reconciler's diagnostics; callers check those before using the
+// result.
+func GetRuleResponse(rc *reconciler, ablyRule *control.RuleResponse, plan *AblyRule) AblyRule {
 	var respTarget any
 
 	switch ablyRule.RuleType {
 	case "aws/kinesis":
 		target, err := unmarshalTarget[control.AWSKinesisTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/kinesis target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/kinesis target: %s", err.Error()))
+			return AblyRule{}
 		}
+		pt := planTarget[AblyRuleTargetKinesis](plan.Target)
 		respTarget = &AblyRuleTargetKinesis{
-			Region:       types.StringValue(target.Region),
-			StreamName:   types.StringValue(target.StreamName),
-			PartitionKey: types.StringValue(target.PartitionKey),
-			AwsAuth:      GetAwsAuth(target.Authentication, plan),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
-			Format:       types.StringValue(target.Format),
+			Region:       rcVal(rc, "target.region", pt.Region, types.StringValue(target.Region), false),
+			StreamName:   rcVal(rc, "target.stream_name", pt.StreamName, types.StringValue(target.StreamName), false),
+			PartitionKey: rcVal(rc, "target.partition_key", pt.PartitionKey, types.StringValue(target.PartitionKey), false),
+			AwsAuth:      GetAwsAuth(rc, target.Authentication, plan),
+			Enveloped:    rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:       rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "aws/sqs":
 		target, err := unmarshalTarget[control.AWSSQSTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/sqs target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/sqs target: %s", err.Error()))
+			return AblyRule{}
 		}
+		pt := planTarget[AblyRuleTargetSqs](plan.Target)
 		respTarget = &AblyRuleTargetSqs{
-			Region:       types.StringValue(target.Region),
-			AwsAccountID: types.StringValue(target.AWSAccountID),
-			QueueName:    types.StringValue(target.QueueName),
-			AwsAuth:      GetAwsAuth(target.Authentication, plan),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
-			Format:       types.StringValue(target.Format),
+			Region:       rcVal(rc, "target.region", pt.Region, types.StringValue(target.Region), false),
+			AwsAccountID: rcVal(rc, "target.aws_account_id", pt.AwsAccountID, types.StringValue(target.AWSAccountID), false),
+			QueueName:    rcVal(rc, "target.queue_name", pt.QueueName, types.StringValue(target.QueueName), false),
+			AwsAuth:      GetAwsAuth(rc, target.Authentication, plan),
+			Enveloped:    rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:       rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "aws/lambda":
 		target, err := unmarshalTarget[control.AWSLambdaTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/lambda target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal aws/lambda target: %s", err.Error()))
+			return AblyRule{}
 		}
+		pt := planTarget[AblyRuleTargetLambda](plan.Target)
 		respTarget = &AblyRuleTargetLambda{
-			Region:       types.StringValue(target.Region),
-			FunctionName: types.StringValue(target.FunctionName),
-			AwsAuth:      GetAwsAuth(target.Authentication, plan),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
+			Region:       rcVal(rc, "target.region", pt.Region, types.StringValue(target.Region), false),
+			FunctionName: rcVal(rc, "target.function_name", pt.FunctionName, types.StringValue(target.FunctionName), false),
+			AwsAuth:      GetAwsAuth(rc, target.Authentication, plan),
+			Enveloped:    rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
 		}
 	case "http/zapier":
 		target, err := unmarshalTarget[control.ZapierRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/zapier target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/zapier target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
+		pt := planTarget[AblyRuleTargetZapier](plan.Target)
 		respTarget = &AblyRuleTargetZapier{
-			Url:          types.StringValue(target.URL),
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Headers:      headers,
+			Url:          rcVal(rc, "target.url", pt.Url, types.StringValue(target.URL), false),
+			SigningKeyId: rcVal(rc, "target.signing_key_id", pt.SigningKeyId, optStringValue(target.SigningKeyID), false),
+			Headers:      rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
 		}
 	case "http/cloudflare-worker":
 		target, err := unmarshalTarget[control.CloudflareWorkerRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/cloudflare-worker target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/cloudflare-worker target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
+		pt := planTarget[AblyRuleTargetCloudflareWorker](plan.Target)
 		respTarget = &AblyRuleTargetCloudflareWorker{
-			Url:          types.StringValue(target.URL),
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Headers:      headers,
+			Url:          rcVal(rc, "target.url", pt.Url, types.StringValue(target.URL), false),
+			SigningKeyId: rcVal(rc, "target.signing_key_id", pt.SigningKeyId, optStringValue(target.SigningKeyID), false),
+			Headers:      rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
 		}
 	case "pulsar":
 		target, err := unmarshalTarget[control.PulsarRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal pulsar target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal pulsar target: %s", err.Error()))
+			return AblyRule{}
 		}
-		// TlsTrustCerts is write-only in the API (accepted on create/update but
-		// never returned on read), so preserve whatever the user configured in
-		// state rather than overwriting it with nil from the API response.
-		var tlsTrustCerts []types.String
-		if p, ok := plan.Target.(*AblyRuleTargetPulsar); ok && p != nil {
-			tlsTrustCerts = p.TlsTrustCerts
-		}
+		pt := planTarget[AblyRuleTargetPulsar](plan.Target)
 		authMode := ""
 		authToken := ""
 		if target.Authentication != nil {
@@ -476,78 +494,80 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			authToken = target.Authentication.Token
 		}
 		respTarget = &AblyRuleTargetPulsar{
-			RoutingKey:    types.StringValue(target.RoutingKey),
-			Topic:         types.StringValue(target.Topic),
-			ServiceURL:    types.StringValue(target.ServiceURL),
-			TlsTrustCerts: tlsTrustCerts,
+			RoutingKey:    rcVal(rc, "target.routing_key", pt.RoutingKey, types.StringValue(target.RoutingKey), false),
+			Topic:         rcVal(rc, "target.topic", pt.Topic, types.StringValue(target.Topic), false),
+			ServiceURL:    rcVal(rc, "target.service_url", pt.ServiceURL, types.StringValue(target.ServiceURL), false),
+			TlsTrustCerts: rcSlice(rc, "target.tls_trust_certs", pt.TlsTrustCerts, toTypedStringSlice(target.TLSTrustCerts), false),
 			Authentication: PulsarAuthentication{
-				Mode:  types.StringValue(authMode),
-				Token: types.StringValue(authToken),
+				Mode:  rcVal(rc, "target.authentication.mode", pt.Authentication.Mode, types.StringValue(authMode), false),
+				Token: rcVal(rc, "target.authentication.token", pt.Authentication.Token, types.StringValue(authToken), false),
 			},
-			Enveloped: types.BoolValue(deref(target.Enveloped)),
-			Format:    types.StringValue(target.Format),
+			Enveloped: rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:    rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "http/ifttt":
 		target, err := unmarshalTarget[control.IFTTTRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/ifttt target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/ifttt target: %s", err.Error()))
+			return AblyRule{}
 		}
+		pt := planTarget[AblyRuleTargetIFTTT](plan.Target)
 		respTarget = &AblyRuleTargetIFTTT{
-			EventName:  types.StringValue(target.EventName),
-			WebhookKey: types.StringValue(target.WebhookKey),
+			EventName:  rcVal(rc, "target.event_name", pt.EventName, types.StringValue(target.EventName), false),
+			WebhookKey: rcVal(rc, "target.webhook_key", pt.WebhookKey, types.StringValue(target.WebhookKey), false),
 		}
 	case "http/google-cloud-function":
 		target, err := unmarshalTarget[control.GoogleCloudFunctionRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/google-cloud-function target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/google-cloud-function target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
+		pt := planTarget[AblyRuleTargetGoogleFunction](plan.Target)
 		respTarget = &AblyRuleTargetGoogleFunction{
-			Region:       types.StringValue(target.Region),
-			ProjectID:    types.StringValue(target.ProjectID),
-			FunctionName: types.StringValue(target.FunctionName),
-			Headers:      headers,
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
-			Format:       types.StringValue(target.Format),
+			Region:       rcVal(rc, "target.region", pt.Region, types.StringValue(target.Region), false),
+			ProjectID:    rcVal(rc, "target.project_id", pt.ProjectID, types.StringValue(target.ProjectID), false),
+			FunctionName: rcVal(rc, "target.function_name", pt.FunctionName, types.StringValue(target.FunctionName), false),
+			Headers:      rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
+			SigningKeyId: rcVal(rc, "target.signing_key_id", pt.SigningKeyId, optStringValue(target.SigningKeyID), false),
+			Enveloped:    rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:       rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "http/azure-function":
 		target, err := unmarshalTarget[control.AzureFunctionRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/azure-function target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http/azure-function target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
+		pt := planTarget[AblyRuleTargetAzureFunction](plan.Target)
 		respTarget = &AblyRuleTargetAzureFunction{
-			AzureAppID:        types.StringValue(target.AzureAppID),
-			AzureFunctionName: types.StringValue(target.AzureFunctionName),
-			Headers:           headers,
-			SigningKeyID:      optStringValue(target.SigningKeyID),
-			Enveloped:         types.BoolValue(deref(target.Enveloped)),
-			Format:            types.StringValue(target.Format),
+			AzureAppID:        rcVal(rc, "target.azure_app_id", pt.AzureAppID, types.StringValue(target.AzureAppID), false),
+			AzureFunctionName: rcVal(rc, "target.function_name", pt.AzureFunctionName, types.StringValue(target.AzureFunctionName), false),
+			Headers:           rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
+			SigningKeyID:      rcVal(rc, "target.signing_key_id", pt.SigningKeyID, optStringValue(target.SigningKeyID), false),
+			Enveloped:         rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:            rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "http":
 		target, err := unmarshalTarget[control.HTTPRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal http target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
+		pt := planTarget[AblyRuleTargetHTTP](plan.Target)
 		respTarget = &AblyRuleTargetHTTP{
-			Url:          types.StringValue(target.URL),
-			Headers:      headers,
-			SigningKeyId: optStringValue(target.SigningKeyID),
-			Format:       types.StringValue(target.Format),
-			Enveloped:    types.BoolValue(deref(target.Enveloped)),
+			Url:          rcVal(rc, "target.url", pt.Url, types.StringValue(target.URL), false),
+			Headers:      rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
+			SigningKeyId: rcVal(rc, "target.signing_key_id", pt.SigningKeyId, optStringValue(target.SigningKeyID), false),
+			Format:       rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
+			Enveloped:    rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
 		}
 	case "kafka":
 		target, err := unmarshalTarget[control.KafkaRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal kafka target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal kafka target: %s", err.Error()))
+			return AblyRule{}
 		}
+		pt := planTarget[AblyRuleTargetKafka](plan.Target)
 		saslMechanism := ""
 		saslUsername := ""
 		saslPassword := ""
@@ -557,82 +577,65 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 			saslPassword = target.Auth.SASL.Password
 		}
 		respTarget = &AblyRuleTargetKafka{
-			RoutingKey: types.StringValue(target.RoutingKey),
-			Brokers:    toTypedStringSlice(target.Brokers),
+			RoutingKey: rcVal(rc, "target.routing_key", pt.RoutingKey, types.StringValue(target.RoutingKey), false),
+			Brokers:    rcSlice(rc, "target.brokers", pt.Brokers, toTypedStringSlice(target.Brokers), false),
 			KafkaAuthentication: KafkaAuthentication{
 				Sasl{
-					Mechanism: types.StringValue(saslMechanism),
-					Username:  types.StringValue(saslUsername),
-					Password:  types.StringValue(saslPassword),
+					Mechanism: rcVal(rc, "target.auth.sasl.mechanism", pt.KafkaAuthentication.Sasl.Mechanism, types.StringValue(saslMechanism), false),
+					Username:  rcVal(rc, "target.auth.sasl.username", pt.KafkaAuthentication.Sasl.Username, types.StringValue(saslUsername), false),
+					Password:  rcVal(rc, "target.auth.sasl.password", pt.KafkaAuthentication.Sasl.Password, types.StringValue(saslPassword), false),
 				},
 			},
-			Enveloped: types.BoolValue(deref(target.Enveloped)),
-			Format:    types.StringValue(target.Format),
+			Enveloped: rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:    rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "amqp":
 		target, err := unmarshalTarget[control.AMQPRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal amqp target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal amqp target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
+		pt := planTarget[AblyRuleTargetAMQP](plan.Target)
 		respTarget = &AblyRuleTargetAMQP{
-			QueueID:   types.StringValue(target.QueueID),
-			Headers:   headers,
-			Enveloped: types.BoolValue(deref(target.Enveloped)),
-			Format:    types.StringValue(target.Format),
+			QueueID:   rcVal(rc, "target.queue_id", pt.QueueID, types.StringValue(target.QueueID), false),
+			Headers:   rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
+			Enveloped: rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:    rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	case "amqp/external":
 		target, err := unmarshalTarget[control.AMQPExternalRuleTarget](ablyRule.Target)
 		if err != nil {
-			diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal amqp/external target: %s", err.Error()))
-			return AblyRule{}, diags
+			rc.diags.AddError("Error unmarshalling rule target", fmt.Sprintf("Could not unmarshal amqp/external target: %s", err.Error()))
+			return AblyRule{}
 		}
-		headers := ToHeaders(target.Headers)
-
-		// Several target fields are not required in the API response and may
-		// be omitted. When the plan provided values for these fields, preserve
-		// them so Terraform doesn't see a diff (the target block contains the
-		// sensitive "url" field, so ANY field mismatch triggers the opaque
-		// "inconsistent values for sensitive attribute" error).
-		url := types.StringValue(target.URL)
-		exchange := types.StringNull()
-		if target.Exchange != "" {
-			exchange = types.StringValue(target.Exchange)
-		}
+		pt := planTarget[AblyRuleTargetAMQPExternal](plan.Target)
+		// The API reports an unset TTL as 0 rather than omitting it. Treat 0
+		// as unset so a config without message_ttl reconciles to null instead
+		// of tripping case 3; a configured 0 still round-trips via case 2.
 		ttl := types.Int64Null()
 		if target.MessageTTL != nil && *target.MessageTTL != 0 {
 			ttl = types.Int64Value(int64(*target.MessageTTL))
 		}
-		if p, ok := plan.Target.(*AblyRuleTargetAMQPExternal); ok && p != nil {
-			if !p.Url.IsNull() {
-				url = p.Url
-			}
-			if target.Exchange == "" {
-				exchange = p.Exchange
-			}
-			if ttl.IsNull() && !p.MessageTtl.IsNull() {
-				ttl = p.MessageTtl
-			}
-		}
 		respTarget = &AblyRuleTargetAMQPExternal{
-			Url:                url,
-			RoutingKey:         types.StringValue(target.RoutingKey),
-			Exchange:           exchange,
-			MandatoryRoute:     types.BoolValue(deref(target.MandatoryRoute)),
-			PersistentMessages: types.BoolValue(deref(target.PersistentMessages)),
-			MessageTtl:         ttl,
-			Headers:            headers,
-			Enveloped:          types.BoolValue(deref(target.Enveloped)),
-			Format:             types.StringValue(target.Format),
+			Url:                rcVal(rc, "target.url", pt.Url, types.StringValue(target.URL), false),
+			RoutingKey:         rcVal(rc, "target.routing_key", pt.RoutingKey, types.StringValue(target.RoutingKey), false),
+			Exchange:           rcVal(rc, "target.exchange", pt.Exchange, optStringValue(&target.Exchange), false),
+			MandatoryRoute:     rcVal(rc, "target.mandatory_route", pt.MandatoryRoute, optBoolValue(target.MandatoryRoute), false),
+			PersistentMessages: rcVal(rc, "target.persistent_messages", pt.PersistentMessages, optBoolValue(target.PersistentMessages), false),
+			MessageTtl:         rcVal(rc, "target.message_ttl", pt.MessageTtl, ttl, false),
+			Headers:            rcSlice(rc, "target.headers", pt.Headers, ToHeaders(target.Headers), false),
+			Enveloped:          rcVal(rc, "target.enveloped", pt.Enveloped, optBoolValue(target.Enveloped), true),
+			Format:             rcVal(rc, "target.format", pt.Format, types.StringValue(target.Format), true),
 		}
 	default:
-		diags.AddError(
+		rc.diags.AddError(
 			"Unknown rule type in response",
 			fmt.Sprintf("Received unrecognized rule type from API: %q", ablyRule.RuleType),
 		)
-		return AblyRule{}, diags
+		return AblyRule{}
 	}
+
+	ps := planTarget[AblyRuleSource](plan.Source)
 
 	channelFilter := types.StringNull()
 	if ablyRule.Source != nil && ablyRule.Source.ChannelFilter != "" {
@@ -645,20 +648,19 @@ func GetRuleResponse(ablyRule *control.RuleResponse, plan *AblyRule) (AblyRule, 
 	}
 
 	respSource := AblyRuleSource{
-		ChannelFilter: channelFilter,
-		Type:          types.StringValue(sourceType),
+		ChannelFilter: rcVal(rc, "source.channel_filter", ps.ChannelFilter, channelFilter, false),
+		Type:          rcVal(rc, "source.type", ps.Type, types.StringValue(sourceType), false),
 	}
-
 	respRule := AblyRule{
-		ID:          types.StringValue(ablyRule.ID),
-		AppID:       types.StringValue(ablyRule.AppID),
-		Status:      types.StringValue(ablyRule.Status),
+		ID:          rcVal(rc, "id", plan.ID, types.StringValue(ablyRule.ID), true),
+		AppID:       rcVal(rc, "app_id", plan.AppID, types.StringValue(ablyRule.AppID), false),
+		Status:      rcVal(rc, "status", plan.Status, types.StringValue(ablyRule.Status), true),
 		Source:      &respSource,
 		Target:      respTarget,
-		RequestMode: types.StringValue(ablyRule.RequestMode),
+		RequestMode: rcVal(rc, "request_mode", plan.RequestMode, types.StringValue(ablyRule.RequestMode), true),
 	}
 
-	return respRule, diags
+	return respRule
 }
 
 // GetRuleSchema returns the schema for a rule resource.
@@ -833,9 +835,9 @@ func CreateRule[T any](r Rule, ctx context.Context, req resource.CreateRequest, 
 		)
 		return
 	}
+	recordCreatedIdentity(ctx, resp, map[string]string{"app_id": plan.AppID.ValueString(), "id": rule.ID})
 
-	responseValues, respDiags := GetRuleResponse(&rule, &plan)
-	resp.Diagnostics.Append(respDiags...)
+	responseValues := GetRuleResponse(newReconciler(&resp.Diagnostics), &rule, &plan)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -880,8 +882,7 @@ func ReadRule[T any](r Rule, ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	responseValues, respDiags := GetRuleResponse(&rule, &state)
-	resp.Diagnostics.Append(respDiags...)
+	responseValues := GetRuleResponse(newReconciler(&resp.Diagnostics).forRead(), &rule, &state)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -929,8 +930,7 @@ func UpdateRule[T any](r Rule, ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	responseValues, respDiags := GetRuleResponse(&rule, &plan)
-	resp.Diagnostics.Append(respDiags...)
+	responseValues := GetRuleResponse(newReconciler(&resp.Diagnostics), &rule, &plan)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/rules_unit_test.go
+++ b/internal/provider/rules_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ably/terraform-provider-ably/control"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -196,13 +197,18 @@ func TestGetAwsAuth_ImportWithNilPlan(t *testing.T) {
 		AccessKeyID:        "AKID",
 	}
 
-	// Simulate import: plan target is a typed nil.
+	// Simulate import: plan target is a typed nil, reconciler in read mode.
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
 	plan := &AblyRule{
 		Target: (*AblyRuleTargetLambda)(nil),
 	}
 
-	result := GetAwsAuth(auth, plan)
+	result := GetAwsAuth(rc, auth, plan)
 
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
 	if result.AuthenticationMode.ValueString() != "credentials" {
 		t.Fatalf("expected mode=credentials, got %q", result.AuthenticationMode.ValueString())
 	}
@@ -219,12 +225,17 @@ func TestGetAwsAuth_AssumeRoleImport(t *testing.T) {
 		AssumeRoleArn:      "arn:aws:iam::123:role/test",
 	}
 
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
 	plan := &AblyRule{
 		Target: (*AblyRuleTargetLambda)(nil),
 	}
 
-	result := GetAwsAuth(auth, plan)
+	result := GetAwsAuth(rc, auth, plan)
 
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
 	if result.AuthenticationMode.ValueString() != "assumeRole" {
 		t.Fatalf("expected mode=assumeRole, got %q", result.AuthenticationMode.ValueString())
 	}

--- a/internal/provider/rules_unit_test.go
+++ b/internal/provider/rules_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ably/terraform-provider-ably/control"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -196,18 +197,102 @@ func TestGetAwsAuth_ImportWithNilPlan(t *testing.T) {
 		AccessKeyID:        "AKID",
 	}
 
-	// Simulate import: plan target is a typed nil.
+	// Simulate import: plan target is a typed nil, reconciler in read mode.
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
 	plan := &AblyRule{
 		Target: (*AblyRuleTargetLambda)(nil),
 	}
 
-	result := GetAwsAuth(auth, plan)
+	result := GetAwsAuth(rc, auth, plan)
 
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
 	if result.AuthenticationMode.ValueString() != "credentials" {
 		t.Fatalf("expected mode=credentials, got %q", result.AuthenticationMode.ValueString())
 	}
 	if result.AccessKeyId.ValueString() != "AKID" {
 		t.Fatalf("expected access_key_id=AKID, got %q", result.AccessKeyId.ValueString())
+	}
+}
+
+// TestGetAwsAuth_ReadModeSwitchClearsStaleCredentials verifies that when the
+// authentication mode changed out-of-band (credentials → assumeRole), Read
+// does not echo the stale credentials fields from prior state.
+func TestGetAwsAuth_ReadModeSwitchClearsStaleCredentials(t *testing.T) {
+	t.Parallel()
+
+	auth := control.AWSAuthentication{
+		AuthenticationMode: "assumeRole",
+		AssumeRoleArn:      "arn:aws:iam::123:role/test",
+	}
+
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
+	plan := &AblyRule{
+		Target: &AblyRuleTargetLambda{
+			AwsAuth: AwsAuth{
+				AuthenticationMode: types.StringValue("credentials"),
+				AccessKeyId:        types.StringValue("stale-key-id"),
+				SecretAccessKey:    types.StringValue("stale-secret"),
+			},
+		},
+	}
+
+	result := GetAwsAuth(rc, auth, plan)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
+	if result.AuthenticationMode.ValueString() != "assumeRole" {
+		t.Fatalf("expected mode=assumeRole, got %q", result.AuthenticationMode.ValueString())
+	}
+	if result.RoleArn.ValueString() != "arn:aws:iam::123:role/test" {
+		t.Fatalf("expected role_arn from API, got %q", result.RoleArn.ValueString())
+	}
+	if !result.AccessKeyId.IsNull() {
+		t.Fatalf("expected stale access_key_id to be cleared, got %q", result.AccessKeyId.ValueString())
+	}
+	if !result.SecretAccessKey.IsNull() {
+		t.Fatalf("expected stale secret_access_key to be cleared, got %q", result.SecretAccessKey.ValueString())
+	}
+}
+
+// TestGetAwsAuth_ReadModeSwitchClearsStaleRoleArn verifies the reverse
+// out-of-band switch (assumeRole → credentials) drops the stale role ARN.
+func TestGetAwsAuth_ReadModeSwitchClearsStaleRoleArn(t *testing.T) {
+	t.Parallel()
+
+	auth := control.AWSAuthentication{
+		AuthenticationMode: "credentials",
+		AccessKeyID:        "new-key-id",
+	}
+
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
+	plan := &AblyRule{
+		Target: &AblyRuleTargetLambda{
+			AwsAuth: AwsAuth{
+				AuthenticationMode: types.StringValue("assumeRole"),
+				RoleArn:            types.StringValue("arn:aws:iam::123:role/stale"),
+			},
+		},
+	}
+
+	result := GetAwsAuth(rc, auth, plan)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
+	if result.AuthenticationMode.ValueString() != "credentials" {
+		t.Fatalf("expected mode=credentials, got %q", result.AuthenticationMode.ValueString())
+	}
+	if result.AccessKeyId.ValueString() != "new-key-id" {
+		t.Fatalf("expected access_key_id from API, got %q", result.AccessKeyId.ValueString())
+	}
+	if !result.RoleArn.IsNull() {
+		t.Fatalf("expected stale role_arn to be cleared, got %q", result.RoleArn.ValueString())
 	}
 }
 
@@ -219,12 +304,17 @@ func TestGetAwsAuth_AssumeRoleImport(t *testing.T) {
 		AssumeRoleArn:      "arn:aws:iam::123:role/test",
 	}
 
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
 	plan := &AblyRule{
 		Target: (*AblyRuleTargetLambda)(nil),
 	}
 
-	result := GetAwsAuth(auth, plan)
+	result := GetAwsAuth(rc, auth, plan)
 
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
 	if result.AuthenticationMode.ValueString() != "assumeRole" {
 		t.Fatalf("expected mode=assumeRole, got %q", result.AuthenticationMode.ValueString())
 	}

--- a/internal/provider/rules_unit_test.go
+++ b/internal/provider/rules_unit_test.go
@@ -217,6 +217,85 @@ func TestGetAwsAuth_ImportWithNilPlan(t *testing.T) {
 	}
 }
 
+// TestGetAwsAuth_ReadModeSwitchClearsStaleCredentials verifies that when the
+// authentication mode changed out-of-band (credentials → assumeRole), Read
+// does not echo the stale credentials fields from prior state.
+func TestGetAwsAuth_ReadModeSwitchClearsStaleCredentials(t *testing.T) {
+	t.Parallel()
+
+	auth := control.AWSAuthentication{
+		AuthenticationMode: "assumeRole",
+		AssumeRoleArn:      "arn:aws:iam::123:role/test",
+	}
+
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
+	plan := &AblyRule{
+		Target: &AblyRuleTargetLambda{
+			AwsAuth: AwsAuth{
+				AuthenticationMode: types.StringValue("credentials"),
+				AccessKeyId:        types.StringValue("stale-key-id"),
+				SecretAccessKey:    types.StringValue("stale-secret"),
+			},
+		},
+	}
+
+	result := GetAwsAuth(rc, auth, plan)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
+	if result.AuthenticationMode.ValueString() != "assumeRole" {
+		t.Fatalf("expected mode=assumeRole, got %q", result.AuthenticationMode.ValueString())
+	}
+	if result.RoleArn.ValueString() != "arn:aws:iam::123:role/test" {
+		t.Fatalf("expected role_arn from API, got %q", result.RoleArn.ValueString())
+	}
+	if !result.AccessKeyId.IsNull() {
+		t.Fatalf("expected stale access_key_id to be cleared, got %q", result.AccessKeyId.ValueString())
+	}
+	if !result.SecretAccessKey.IsNull() {
+		t.Fatalf("expected stale secret_access_key to be cleared, got %q", result.SecretAccessKey.ValueString())
+	}
+}
+
+// TestGetAwsAuth_ReadModeSwitchClearsStaleRoleArn verifies the reverse
+// out-of-band switch (assumeRole → credentials) drops the stale role ARN.
+func TestGetAwsAuth_ReadModeSwitchClearsStaleRoleArn(t *testing.T) {
+	t.Parallel()
+
+	auth := control.AWSAuthentication{
+		AuthenticationMode: "credentials",
+		AccessKeyID:        "new-key-id",
+	}
+
+	var diags diag.Diagnostics
+	rc := newReconciler(&diags).forRead()
+	plan := &AblyRule{
+		Target: &AblyRuleTargetLambda{
+			AwsAuth: AwsAuth{
+				AuthenticationMode: types.StringValue("assumeRole"),
+				RoleArn:            types.StringValue("arn:aws:iam::123:role/stale"),
+			},
+		},
+	}
+
+	result := GetAwsAuth(rc, auth, plan)
+
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors()[0].Detail())
+	}
+	if result.AuthenticationMode.ValueString() != "credentials" {
+		t.Fatalf("expected mode=credentials, got %q", result.AuthenticationMode.ValueString())
+	}
+	if result.AccessKeyId.ValueString() != "new-key-id" {
+		t.Fatalf("expected access_key_id from API, got %q", result.AccessKeyId.ValueString())
+	}
+	if !result.RoleArn.IsNull() {
+		t.Fatalf("expected stale role_arn to be cleared, got %q", result.RoleArn.ValueString())
+	}
+}
+
 func TestGetAwsAuth_AssumeRoleImport(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This should result in the TF provider being a little more resistant to upstream field changes.

Additionally, adds tests that check if any unexpected fields are returned when a minimal (required-only) config is sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more acceptance coverage for “minimal” Terraform configurations across apps, keys, namespaces, queues, and rule resources, including Plan-only stability checks.

* **Bug Fixes**
  * Fixed cases where defaults could be skipped when values were left unspecified or were unknown during planning.
  * Improved state consistency after apply and refresh, ensuring computed fields and server-provided values are reflected correctly for apps, keys, namespaces, queues, and ingress/rule resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->