### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Test
         run: |
           echo "provider_installation { dev_overrides { \"registry.terraform.io/ably/ably\" = \"$PWD/bin\", } direct {} }" > ~/.terraformrc
-          TF_ACC=1 go test -v -parallel 4 ./...
+          TF_ACC=1 go test -v -parallel 4 -timeout 20m ./...
         env:
           ABLY_ACCOUNT_TOKEN: ${{ secrets.ABLY_ACCOUNT_TOKEN }}
           ABLY_URL: 'https://staging-control.ably-dev.net/v1'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
         go-version: [1.23, 1.24]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           submodules: 'recursive'
           persist-credentials: false

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,13 +21,13 @@ jobs:
         go-version: [1.23, 1.24]
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,13 +21,13 @@ jobs:
         go-version: [1.23, 1.24]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
           go-version: ${{ matrix.go-version }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,9 +8,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       provider_prev: ${{ steps.detect.outputs.provider_prev }}
       control_prev: ${{ steps.detect.outputs.control_prev }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -93,19 +93,19 @@ jobs:
     steps:
       # Check out the exact commit the provider tag points to,
       # so GoReleaser builds the right code.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.detect.outputs.provider_tag }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: 'go.mod'
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@d6f3f49f3345e29369fe57596a3ca8f94c4d2ca7 # v5.4.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.TERRAFORM_REGISTRY_PRIVATE_KEY }}
@@ -116,7 +116,7 @@ jobs:
       # GORELEASER_CURRENT_TAG / _PREVIOUS_TAG override auto-detection
       # so that control/v* tags don't confuse it.
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: latest
           args: release --clean
@@ -136,7 +136,7 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.detect.outputs.control_tag }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,9 +152,11 @@ jobs:
       - name: Generate scoped release notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONTROL_TAG: ${{ needs.detect.outputs.control_tag }}
+          CONTROL_PREV: ${{ needs.detect.outputs.control_prev }}
         run: |
-          tag="${{ needs.detect.outputs.control_tag }}"
-          prev="${{ needs.detect.outputs.control_prev }}"
+          tag="$CONTROL_TAG"
+          prev="$CONTROL_PREV"
           since=$([ -n "$prev" ] && git log -1 --format=%aI "$prev" || echo "1970-01-01T00:00:00Z")
 
           gh pr list --repo "$GITHUB_REPOSITORY" \
@@ -185,8 +187,9 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONTROL_TAG: ${{ needs.detect.outputs.control_tag }}
         run: |
-          gh release create "${{ needs.detect.outputs.control_tag }}" \
-            --title "Release ${{ needs.detect.outputs.control_tag }}" \
+          gh release create "$CONTROL_TAG" \
+            --title "Release $CONTROL_TAG" \
             --notes-file "$RUNNER_TEMP/notes.md" \
             --draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       provider_prev: ${{ steps.detect.outputs.provider_prev }}
       control_prev: ${{ steps.detect.outputs.control_prev }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -93,7 +93,7 @@ jobs:
     steps:
       # Check out the exact commit the provider tag points to,
       # so GoReleaser builds the right code.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.provider_tag }}
           fetch-depth: 0
@@ -136,7 +136,7 @@ jobs:
       contents: write
       pull-requests: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.detect.outputs.control_tag }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,15 @@ name: Release
 on:
   workflow_dispatch: {}
 
-permissions:
-  contents: write
+permissions: {}
 
 # ─── Detect which components need releasing ──────────────────────────
 
 jobs:
   detect:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       provider_tag: ${{ steps.detect.outputs.provider_tag }}
       control_tag: ${{ steps.detect.outputs.control_tag }}
@@ -87,6 +88,8 @@ jobs:
     needs: detect
     if: needs.detect.outputs.provider_tag != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Check out the exact commit the provider tag points to,
       # so GoReleaser builds the right code.
@@ -129,6 +132,9 @@ jobs:
     needs: detect
     if: needs.detect.outputs.control_tag != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect unreleased tags
         id: detect
@@ -93,6 +94,7 @@ jobs:
         with:
           ref: ${{ needs.detect.outputs.provider_tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -132,6 +134,7 @@ jobs:
         with:
           ref: ${{ needs.detect.outputs.control_tag }}
           fetch-depth: 0
+          persist-credentials: false
 
       # Build release notes from PRs that touch control/ paths only,
       # so provider-only changes don't leak into the control changelog.


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into four commits, one per finding type:

- Disable credential persistence on actions/checkout steps so the default GITHUB_TOKEN is not left in the local git config after checkout.
- Scope each job's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs.
- Move workflow-context expansions (${{ needs.detect.outputs.* }}) out of run: shell source and into env: bindings.
- Pin all third-party actions to commit SHAs (with the tag preserved as a comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflows run the same checks and the same release steps against the same inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened GitHub Actions workflows with least-privilege permissions at workflow and job levels.
  * Pinned CI/CD third-party actions to exact commit SHAs for more reproducible runs.
  * Reduced credential persistence during repository checkout.
  * Added a 20-minute timeout to CI tests.
  * Simplified the control release notes flow by passing tag/version values via job environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->