### PR TITLE
[INF-7589] Switch from `authenticated` field to `identified`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,11 @@ jobs:
           mkdir bin
           go build -v -o bin
 
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e
+        with:
+          terraform_wrapper: false
+
       - name: Test
         run: |
           echo "provider_installation { dev_overrides { \"registry.terraform.io/ably/ably\" = \"$PWD/bin\", } direct {} }" > ~/.terraformrc

--- a/control/types.go
+++ b/control/types.go
@@ -137,8 +137,14 @@ type KeyResponse struct {
 // ID is the namespace prefix (e.g. "chat"); boolean fields default to
 // false when omitted.
 type NamespacePost struct {
-	ID                      string  `json:"id"`
-	Authenticated           bool    `json:"authenticated"`
+	ID string `json:"id"`
+	// Identified is the canonical field; Authenticated is a legacy alias for the
+	// same setting. Both are pointers with omitempty so an unset alias is
+	// dropped from the body rather than sent alongside the other (which the
+	// server would treat as a conflicting pair). The provider only ever sets
+	// Identified.
+	Identified              *bool   `json:"identified,omitempty"`
+	Authenticated           *bool   `json:"authenticated,omitempty"`
 	Persisted               bool    `json:"persisted"`
 	PersistLast             bool    `json:"persistLast"`
 	PushEnabled             bool    `json:"pushEnabled"`
@@ -156,6 +162,7 @@ type NamespacePost struct {
 // NamespacePatch is the request body for [Client.UpdateNamespace]. This
 // is a partial update — only non-nil fields are sent.
 type NamespacePatch struct {
+	Identified              *bool   `json:"identified,omitempty"`
 	Authenticated           *bool   `json:"authenticated,omitempty"`
 	Persisted               *bool   `json:"persisted,omitempty"`
 	PersistLast             *bool   `json:"persistLast,omitempty"`
@@ -174,6 +181,7 @@ type NamespacePatch struct {
 // NamespaceResponse is the response for namespace operations.
 type NamespaceResponse struct {
 	AppID                   string  `json:"appId,omitempty"`
+	Identified              *bool   `json:"identified,omitempty"`
 	Authenticated           bool    `json:"authenticated"`
 	Created                 int64   `json:"created,omitempty"`
 	Modified                int64   `json:"modified,omitempty"`

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -16,7 +16,7 @@ The Ably namespace resource allows you to manage namespaces for channel rules in
 resource "ably_namespace" "namespace0" {
   app_id            = ably_app.app0.id
   id                = "namespace"
-  authenticated     = false
+  identified        = false
   persisted         = false
   persist_last      = false
   push_enabled      = false
@@ -27,7 +27,7 @@ resource "ably_namespace" "namespace0" {
 resource "ably_namespace" "namespace_batching" {
   app_id            = ably_app.app0.id
   id                = "namespace"
-  authenticated     = false
+  identified        = false
   persisted         = false
   persist_last      = false
   push_enabled      = false
@@ -40,7 +40,7 @@ resource "ably_namespace" "namespace_batching" {
 resource "ably_namespace" "namespace_conflation" {
   app_id              = ably_app.app0.id
   id                  = "namespace"
-  authenticated       = false
+  identified          = false
   persisted           = false
   persist_last        = false
   push_enabled        = false
@@ -62,13 +62,14 @@ resource "ably_namespace" "namespace_conflation" {
 
 ### Optional
 
-- `authenticated` (Boolean) Require clients to be authenticated to use channels in this namespace.
+- `authenticated` (Boolean, Deprecated) Deprecated alias for `identified`. Require clients to be identified to use channels in this namespace.
 - `batching_enabled` (Boolean) If true, channels within this namespace will start batching inbound messages instead of sending them out immediately to subscribers as per the configured policy.
 - `batching_interval` (Number) When configured, sets the maximium batching interval in the channel.
 - `conflation_enabled` (Boolean) If true, enables conflation for channels within this namespace. Conflation reduces the number of messages sent to subscribers by combining multiple messages into a single message.
 - `conflation_interval` (Number) The interval in milliseconds at which messages are conflated. This determines how frequently messages are combined into a single message.
 - `conflation_key` (String) The key used to determine which messages should be conflated. Messages with the same conflation key will be combined into a single message.
 - `expose_timeserial` (Boolean) If true, messages received on a channel will contain a unique timeserial that can be referenced by later messages for use with message interactions.
+- `identified` (Boolean) Require clients to be identified (authenticated with a client ID) to use channels in this namespace. See https://ably.com/docs/auth/identified-clients.
 - `mutable_messages` (Boolean) Enables message editing and deletion on the namespace. When enabled, messages published to channels matching this namespace can be modified or deleted.
 - `persist_last` (Boolean) If true, the last message on each channel will persist for 365 days.
 - `persisted` (Boolean) If true, messages will be stored for 24 hours.

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -64,7 +64,7 @@ resource "ably_namespace" "namespace_conflation" {
 
 - `authenticated` (Boolean, Deprecated) Deprecated alias for `identified`. Require clients to be identified to use channels in this namespace.
 - `batching_enabled` (Boolean) If true, channels within this namespace will start batching inbound messages instead of sending them out immediately to subscribers as per the configured policy.
-- `batching_interval` (Number) When configured, sets the maximium batching interval in the channel.
+- `batching_interval` (Number) When configured, sets the maximum batching interval in the channel.
 - `conflation_enabled` (Boolean) If true, enables conflation for channels within this namespace. Conflation reduces the number of messages sent to subscribers by combining multiple messages into a single message.
 - `conflation_interval` (Number) The interval in milliseconds at which messages are conflated. This determines how frequently messages are combined into a single message.
 - `conflation_key` (String) The key used to determine which messages should be conflated. Messages with the same conflation key will be combined into a single message.

--- a/examples/resources/namespace.tf
+++ b/examples/resources/namespace.tf
@@ -1,7 +1,7 @@
 resource "ably_namespace" "namespace0" {
   app_id            = ably_app.app0.id
   id                = "namespace"
-  authenticated     = false
+  identified        = false
   persisted         = false
   persist_last      = false
   push_enabled      = false
@@ -12,7 +12,7 @@ resource "ably_namespace" "namespace0" {
 resource "ably_namespace" "namespace_batching" {
   app_id            = ably_app.app0.id
   id                = "namespace"
-  authenticated     = false
+  identified        = false
   persisted         = false
   persist_last      = false
   push_enabled      = false
@@ -25,7 +25,7 @@ resource "ably_namespace" "namespace_batching" {
 resource "ably_namespace" "namespace_conflation" {
   app_id              = ably_app.app0.id
   id                  = "namespace"
-  authenticated       = false
+  identified          = false
   persisted           = false
   persist_last        = false
   push_enabled        = false

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -36,6 +36,7 @@ type AblyApp struct {
 type AblyNamespace struct {
 	AppID                   types.String `tfsdk:"app_id"`
 	ID                      types.String `tfsdk:"id"`
+	Identified              types.Bool   `tfsdk:"identified"`
 	Authenticated           types.Bool   `tfsdk:"authenticated"`
 	Persisted               types.Bool   `tfsdk:"persisted"`
 	PersistLast             types.Bool   `tfsdk:"persist_last"`

--- a/internal/provider/modifiers.go
+++ b/internal/provider/modifiers.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -36,6 +37,62 @@ func (m defaultBoolModifier) PlanModifyBool(_ context.Context, req planmodifier.
 // DefaultBoolAttribute returns a plan modifier that sets a default bool value.
 func DefaultBoolAttribute(value types.Bool) planmodifier.Bool {
 	return defaultBoolModifier{value: value}
+}
+
+// aliasBoolModifier mirrors one half of a pair of aliased boolean attributes
+// (e.g. a canonical attribute and its deprecated alias). The two are mutually
+// exclusive in config, so at most one is ever set. When this attribute is not
+// configured it takes the value of the other alias if that is set; otherwise it
+// falls back to a default on create and keeps the prior state value on update.
+type aliasBoolModifier struct {
+	other path.Path
+	value types.Bool
+}
+
+func (m aliasBoolModifier) Description(_ context.Context) string {
+	return "Mirrors the value of an aliased attribute, defaulting when neither is set."
+}
+
+func (m aliasBoolModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m aliasBoolModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// Configured explicitly: keep the configured value.
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+
+	// Mirror the other alias when it is configured. The two always hold the
+	// same value, so copying it keeps plan and result in agreement.
+	var other types.Bool
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, m.other, &other)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if !other.IsNull() {
+		// The other alias drives the value. If it isn't known yet (e.g. it
+		// references an unresolved value), leave this attribute unknown so the
+		// mirrored result is accepted after apply rather than clashing with a
+		// stale planned value.
+		if other.IsUnknown() {
+			resp.PlanValue = types.BoolUnknown()
+		} else {
+			resp.PlanValue = other
+		}
+		return
+	}
+
+	// Neither alias is set: default on create, keep prior state on update.
+	if req.PlanValue.IsNull() {
+		resp.PlanValue = m.value
+	}
+}
+
+// AliasBoolAttribute returns a plan modifier for one half of a pair of aliased
+// boolean attributes. See [aliasBoolModifier].
+func AliasBoolAttribute(other path.Path, value types.Bool) planmodifier.Bool {
+	return aliasBoolModifier{other: other, value: value}
 }
 
 // defaultInt64Modifier implements planmodifier.Int64.

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -131,7 +131,7 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"batching_interval": schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "When configured, sets the maximium batching interval in the channel.",
+				Description: "When configured, sets the maximum batching interval in the channel.",
 				PlanModifiers: []planmodifier.Int64{
 					DefaultInt64Attribute(types.Int64Null()),
 				},

--- a/internal/provider/resource_ably_namespace.go
+++ b/internal/provider/resource_ably_namespace.go
@@ -5,7 +5,9 @@ import (
 	"context"
 
 	"github.com/ably/terraform-provider-ably/control"
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -39,12 +41,27 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"authenticated": schema.BoolAttribute{
+			"identified": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "Require clients to be authenticated to use channels in this namespace.",
+				Description: "Require clients to be identified (authenticated with a client ID) to use channels in this namespace. See https://ably.com/docs/auth/identified-clients.",
 				PlanModifiers: []planmodifier.Bool{
-					DefaultBoolAttribute(types.BoolValue(false)),
+					AliasBoolAttribute(path.Root("authenticated"), types.BoolValue(false)),
+				},
+				Validators: []validator.Bool{
+					boolvalidator.ConflictsWith(path.MatchRoot("authenticated")),
+				},
+			},
+			"authenticated": schema.BoolAttribute{
+				Optional:           true,
+				Computed:           true,
+				DeprecationMessage: "Use `identified` instead. `authenticated` is a legacy alias and will be removed in a future major version.",
+				Description:        "Deprecated alias for `identified`. Require clients to be identified to use channels in this namespace.",
+				PlanModifiers: []planmodifier.Bool{
+					AliasBoolAttribute(path.Root("identified"), types.BoolValue(false)),
+				},
+				Validators: []validator.Bool{
+					boolvalidator.ConflictsWith(path.MatchRoot("identified")),
 				},
 			},
 			"persisted": schema.BoolAttribute{
@@ -154,6 +171,29 @@ func (r ResourceNamespace) Schema(_ context.Context, _ resource.SchemaRequest, r
 	}
 }
 
+// namespaceIdentified returns the effective "identified" value from a plan,
+// preferring the canonical identified attribute and falling back to the
+// deprecated authenticated alias. The two are mutually exclusive in config.
+func namespaceIdentified(plan AblyNamespace) bool {
+	if !plan.Identified.IsNull() && !plan.Identified.IsUnknown() {
+		return plan.Identified.ValueBool()
+	}
+	if !plan.Authenticated.IsNull() && !plan.Authenticated.IsUnknown() {
+		return plan.Authenticated.ValueBool()
+	}
+	return false
+}
+
+// namespaceIdentifiedValue extracts the server's identified value from a
+// response, preferring the canonical identified field and falling back to the
+// authenticated alias for Control API versions that don't yet return it.
+func namespaceIdentifiedValue(n control.NamespaceResponse) bool {
+	if n.Identified != nil {
+		return *n.Identified
+	}
+	return n.Authenticated
+}
+
 // Create creates a new resource.
 func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	if !r.p.ensureConfigured(&resp.Diagnostics) {
@@ -171,7 +211,7 @@ func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateReques
 	// Generates an API request body from the plan values
 	namespaceValues := control.NamespacePost{
 		ID:                      plan.ID.ValueString(),
-		Authenticated:           plan.Authenticated.ValueBool(),
+		Identified:              ptr(namespaceIdentified(plan)),
 		Persisted:               plan.Persisted.ValueBool(),
 		PersistLast:             plan.PersistLast.ValueBool(),
 		PushEnabled:             plan.PushEnabled.ValueBool(),
@@ -213,7 +253,8 @@ func (r ResourceNamespace) Create(ctx context.Context, req resource.CreateReques
 	respApps := AblyNamespace{
 		AppID:                   types.StringValue(plan.AppID.ValueString()),
 		ID:                      types.StringValue(ablyNamespace.ID),
-		Authenticated:           types.BoolValue(ablyNamespace.Authenticated),
+		Identified:              types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
+		Authenticated:           types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
 		Persisted:               types.BoolValue(ablyNamespace.Persisted),
 		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
 		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),
@@ -287,7 +328,8 @@ func (r ResourceNamespace) Read(ctx context.Context, req resource.ReadRequest, r
 			respNamespaces := AblyNamespace{
 				AppID:                   types.StringValue(appID),
 				ID:                      types.StringValue(namespaceID),
-				Authenticated:           types.BoolValue(v.Authenticated),
+				Identified:              types.BoolValue(namespaceIdentifiedValue(v)),
+				Authenticated:           types.BoolValue(namespaceIdentifiedValue(v)),
 				Persisted:               types.BoolValue(v.Persisted),
 				PersistLast:             types.BoolValue(v.PersistLast),
 				PushEnabled:             types.BoolValue(v.PushEnabled),
@@ -345,7 +387,7 @@ func (r ResourceNamespace) Update(ctx context.Context, req resource.UpdateReques
 
 	// Instantiates struct of type control.NamespacePatch and sets values to output of plan
 	namespaceValues := control.NamespacePatch{
-		Authenticated:           ptr(plan.Authenticated.ValueBool()),
+		Identified:              ptr(namespaceIdentified(plan)),
 		Persisted:               ptr(plan.Persisted.ValueBool()),
 		PersistLast:             ptr(plan.PersistLast.ValueBool()),
 		PushEnabled:             ptr(plan.PushEnabled.ValueBool()),
@@ -388,7 +430,8 @@ func (r ResourceNamespace) Update(ctx context.Context, req resource.UpdateReques
 	respNamespaces := AblyNamespace{
 		AppID:                   types.StringValue(appID),
 		ID:                      types.StringValue(ablyNamespace.ID),
-		Authenticated:           types.BoolValue(ablyNamespace.Authenticated),
+		Identified:              types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
+		Authenticated:           types.BoolValue(namespaceIdentifiedValue(ablyNamespace)),
 		Persisted:               types.BoolValue(ablyNamespace.Persisted),
 		PersistLast:             types.BoolValue(ablyNamespace.PersistLast),
 		PushEnabled:             types.BoolValue(ablyNamespace.PushEnabled),

--- a/internal/provider/resource_ably_namespace_test.go
+++ b/internal/provider/resource_ably_namespace_test.go
@@ -23,7 +23,7 @@ func TestAccAblyNamespace(t *testing.T) {
 			{
 				Config: testAccAblyNamespaceConfig(appName, control.NamespacePost{
 					ID:                      namespaceName,
-					Authenticated:           true,
+					Authenticated:           ptr(true),
 					Persisted:               true,
 					PersistLast:             true,
 					PushEnabled:             true,
@@ -36,6 +36,8 @@ func TestAccAblyNamespace(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_app.app0", "name", appName),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "id", namespaceName),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "authenticated", "true"),
+					// identified mirrors the deprecated authenticated alias.
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "identified", "true"),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "persisted", "true"),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "persist_last", "true"),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "push_enabled", "true"),
@@ -63,7 +65,7 @@ func TestAccAblyNamespace(t *testing.T) {
 			{
 				Config: testAccAblyNamespaceConfig(appName, control.NamespacePost{
 					ID:                      namespaceName,
-					Authenticated:           false,
+					Authenticated:           ptr(false),
 					Persisted:               false,
 					PersistLast:             false,
 					PushEnabled:             false,
@@ -76,6 +78,7 @@ func TestAccAblyNamespace(t *testing.T) {
 					resource.TestCheckResourceAttr("ably_app.app0", "name", appName),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "id", namespaceName),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "authenticated", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "identified", "false"),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "persisted", "false"),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "persist_last", "false"),
 					resource.TestCheckResourceAttr("ably_namespace.namespace0", "push_enabled", "false"),
@@ -88,7 +91,7 @@ func TestAccAblyNamespace(t *testing.T) {
 			{
 				Config: testAccAblyNamespaceConfig(appName, control.NamespacePost{
 					ID:               namespaceName + "new",
-					Authenticated:    false,
+					Authenticated:    ptr(false),
 					Persisted:        false,
 					PersistLast:      false,
 					PushEnabled:      false,
@@ -109,7 +112,7 @@ func TestAccAblyNamespace(t *testing.T) {
 			{
 				Config: testAccAblyNamespaceBatchingConfig(appName, control.NamespacePost{
 					ID:               namespaceName + "batching",
-					Authenticated:    false,
+					Authenticated:    ptr(false),
 					Persisted:        false,
 					PersistLast:      false,
 					PushEnabled:      false,
@@ -134,7 +137,7 @@ func TestAccAblyNamespace(t *testing.T) {
 			{
 				Config: testAccAblyNamespaceConflationConfig(appName, control.NamespacePost{
 					ID:                 namespaceName + "conflation",
-					Authenticated:      false,
+					Authenticated:      ptr(false),
 					Persisted:          false,
 					PersistLast:        false,
 					PushEnabled:        false,
@@ -199,7 +202,7 @@ resource "ably_namespace" "namespace0" {
 `,
 		appName,
 		namespace.ID,
-		namespace.Authenticated,
+		*namespace.Authenticated,
 		namespace.Persisted,
 		namespace.PersistLast,
 		namespace.PushEnabled,
@@ -244,7 +247,7 @@ resource "ably_namespace" "namespace0" {
 `,
 		appName,
 		namespace.ID,
-		namespace.Authenticated,
+		*namespace.Authenticated,
 		namespace.Persisted,
 		namespace.PersistLast,
 		namespace.PushEnabled,
@@ -290,7 +293,7 @@ resource "ably_namespace" "namespace0" {
 `,
 		appName,
 		namespace.ID,
-		namespace.Authenticated,
+		*namespace.Authenticated,
 		namespace.Persisted,
 		namespace.PersistLast,
 		namespace.PushEnabled,
@@ -300,6 +303,93 @@ resource "ably_namespace" "namespace0" {
 		*namespace.ConflationInterval,
 		*namespace.ConflationKey,
 	)
+}
+
+// TestAccAblyNamespace_Identified exercises the canonical identified attribute
+// and confirms the deprecated authenticated alias mirrors it in state.
+func TestAccAblyNamespace_Identified(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	namespaceName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAblyNamespaceIdentifiedConfig(appName, namespaceName, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "id", namespaceName),
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "identified", "true"),
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "authenticated", "true"),
+				),
+			},
+			{
+				Config: testAccAblyNamespaceIdentifiedConfig(appName, namespaceName, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "id", namespaceName),
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "identified", "false"),
+					resource.TestCheckResourceAttr("ably_namespace.namespace0", "authenticated", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAblyNamespaceIdentifiedConfig(appName, namespaceName string, identified bool) string {
+	return fmt.Sprintf(`
+terraform {
+	required_providers {
+		ably = {
+			source = "registry.terraform.io/ably/ably"
+		}
+	}
+}
+provider "ably" {}
+
+resource "ably_app" "app0" {
+	name     = %[1]q
+	status   = "enabled"
+	tls_only = true
+}
+
+resource "ably_namespace" "namespace0" {
+  app_id     = ably_app.app0.id
+  id         = %[2]q
+  identified = %[3]t
+}
+`, appName, namespaceName, identified)
+}
+
+// TestAccAblyNamespace_ConflictingIdentifiedAuthenticated confirms that setting
+// both the canonical identified attribute and its deprecated authenticated alias
+// is rejected at plan time by the ConflictsWith validator.
+func TestAccAblyNamespace_ConflictingIdentifiedAuthenticated(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+terraform {
+	required_providers {
+		ably = {
+			source = "registry.terraform.io/ably/ably"
+		}
+	}
+}
+provider "ably" {}
+resource "ably_app" "app0" { name = %q }
+resource "ably_namespace" "ns0" {
+	app_id        = ably_app.app0.id
+	id            = "test-ns"
+	identified    = true
+	authenticated = true
+}
+`, appName),
+				ExpectError: regexp.MustCompile(`(?s).*cannot be specified when.*`),
+			},
+		},
+	})
 }
 
 func TestAccAblyNamespace_InvalidBatchingInterval(t *testing.T) {


### PR DESCRIPTION
The `authenticated` field has been deprecated for a while in the realtime backend, but the Control API was never updated to use it. The fix in the Control API has now been applied, so we can now update the Terraform provider to use the correct field.

The `authenticated` field stays but as a deprecated field.

This also includes a fix for the GitHub Action Terraform run to install Terraform directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canonical `identified` field to namespace resources to control client identification requirements.
  * Kept `authenticated` as a deprecated alias, with validation preventing setting both at the same time.
* **Documentation**
  * Updated namespace documentation and examples to use `identified`, noting `authenticated` as deprecated.
* **Tests**
  * Extended acceptance coverage to ensure `identified` and `authenticated` stay in sync and conflicts are rejected.
* **Chores**
  * Updated CI to install Terraform via a dedicated setup step before running tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->