### PR TITLE
[INF-7769] Make retries more conservative

### DIFF
--- a/control/client.go
+++ b/control/client.go
@@ -16,7 +16,7 @@
 //	}
 //
 // Requests that fail with 5xx status codes are retried automatically
-// (up to 4 times by default, with exponential backoff). Client errors
+// (up to 2 times by default, with exponential backoff). Client errors
 // (4xx) are never retried.
 package control
 
@@ -30,6 +30,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
 )
@@ -37,6 +38,20 @@ import (
 // Version is the semantic version of this library, used in the default
 // User-Agent header.
 const Version = "0.1.0"
+
+// Default retry configuration. These are deliberately conservative so a
+// struggling API server isn't hammered by a retry storm: a small number of
+// attempts with a comparatively long backoff gives the server room to
+// recover rather than amplifying load while it's already shedding requests.
+const (
+	// DefaultRetryMax is the default maximum number of retries on 5xx and
+	// connection errors.
+	DefaultRetryMax = 2
+	// DefaultRetryWaitMin is the default minimum wait between retries.
+	DefaultRetryWaitMin = 2 * time.Second
+	// DefaultRetryWaitMax is the default maximum wait between retries.
+	DefaultRetryWaitMax = 60 * time.Second
+)
 
 var defaultUserAgent = "ably-control-api/" + Version
 
@@ -52,7 +67,7 @@ type Client struct {
 	//   client.UserAgent += " ably-terraform/1.0.0"
 	UserAgent string
 	// HTTPClient is the retryable HTTP client used for requests.
-	// By default it retries up to 4 times with exponential backoff
+	// By default it retries up to 2 times with exponential backoff
 	// on 5xx responses and connection errors.
 	HTTPClient *retryablehttp.Client
 }
@@ -61,10 +76,26 @@ type Client struct {
 type ClientOption func(*Client)
 
 // WithRetryMax sets the maximum number of retries for failed requests.
-// Set to 0 to disable retries. Default is 4.
+// Set to 0 to disable retries. Default is [DefaultRetryMax].
 func WithRetryMax(n int) ClientOption {
 	return func(c *Client) {
 		c.HTTPClient.RetryMax = n
+	}
+}
+
+// WithRetryWaitMin sets the minimum wait between retries. This is the base
+// for the exponential backoff. Default is [DefaultRetryWaitMin].
+func WithRetryWaitMin(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.HTTPClient.RetryWaitMin = d
+	}
+}
+
+// WithRetryWaitMax sets the maximum wait between retries, capping the
+// exponential backoff. Default is [DefaultRetryWaitMax].
+func WithRetryWaitMax(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.HTTPClient.RetryWaitMax = d
 	}
 }
 
@@ -90,13 +121,17 @@ func WithHTTPClient(hc *http.Client) ClientOption {
 // Defaults:
 //   - Base URL: https://control.ably.net/v1
 //   - User-Agent: ably-control-api/<Version>
-//   - Retry: up to 4 attempts with exponential backoff on 5xx and
+//   - Retry: up to [DefaultRetryMax] attempts with exponential backoff
+//     (between [DefaultRetryWaitMin] and [DefaultRetryWaitMax]) on 5xx and
 //     connection errors; 4xx responses are never retried
 //
-// Use [WithRetryMax], [WithUserAgent], or [WithHTTPClient] to override.
+// Use [WithRetryMax], [WithRetryWaitMin], [WithRetryWaitMax],
+// [WithUserAgent], or [WithHTTPClient] to override.
 func NewClient(token string, opts ...ClientOption) *Client {
 	rc := retryablehttp.NewClient()
-	rc.RetryMax = 4
+	rc.RetryMax = DefaultRetryMax
+	rc.RetryWaitMin = DefaultRetryWaitMin
+	rc.RetryWaitMax = DefaultRetryWaitMax
 	rc.Logger = nil // silence default logger
 	rc.CheckRetry = retryPolicy
 	rc.ErrorHandler = retryablehttp.PassthroughErrorHandler

--- a/control/client_test.go
+++ b/control/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,6 +121,18 @@ func TestRetry_WithRetryMaxOption(t *testing.T) {
 	assert.Equal(t, int32(2), attempts.Load()) // 1 initial + 1 retry
 }
 
+func TestRetry_WithRetryWaitOptions(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient(
+		"test-token",
+		WithRetryWaitMin(5*time.Second),
+		WithRetryWaitMax(90*time.Second),
+	)
+	assert.Equal(t, 5*time.Second, client.HTTPClient.RetryWaitMin)
+	assert.Equal(t, 90*time.Second, client.HTTPClient.RetryWaitMax)
+}
+
 // ---------------------------------------------------------------------------
 // User-Agent
 // ---------------------------------------------------------------------------
@@ -196,7 +209,9 @@ func TestNewClient_Defaults(t *testing.T) {
 	assert.Equal(t, "my-token", client.Token)
 	assert.Equal(t, "https://control.ably.net/v1", client.BaseURL)
 	assert.Equal(t, "ably-control-api/"+Version, client.UserAgent)
-	assert.Equal(t, 4, client.HTTPClient.RetryMax)
+	assert.Equal(t, DefaultRetryMax, client.HTTPClient.RetryMax)
+	assert.Equal(t, DefaultRetryWaitMin, client.HTTPClient.RetryWaitMin)
+	assert.Equal(t, DefaultRetryWaitMax, client.HTTPClient.RetryWaitMax)
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,5 +88,8 @@ This will add the app to your Terraform state file. You can then run `terraform 
 
 ### Optional
 
+- `retry_max` (Number) Maximum number of times a failed Control API request is retried (on 5xx and connection errors; 4xx responses are never retried). Set to 0 to disable retries. Can also be set via the `ABLY_RETRY_MAX` environment variable. Defaults to 2.
+- `retry_wait_max_seconds` (Number) Maximum wait, in seconds, between retries, capping the exponential backoff. Can also be set via the `ABLY_RETRY_WAIT_MAX_SECONDS` environment variable. Defaults to 60.
+- `retry_wait_min_seconds` (Number) Minimum wait, in seconds, between retries. This is the base for the exponential backoff. Can also be set via the `ABLY_RETRY_WAIT_MIN_SECONDS` environment variable. Defaults to 2.
 - `token` (String, Sensitive) The Ably account token used for authentication. Can also be set via the `ABLY_ACCOUNT_TOKEN` environment variable.
 - `url` (String) The Ably Control API URL. Can also be set via the `ABLY_URL` environment variable. Defaults to the production API.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,7 +3,10 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -55,14 +58,29 @@ func (p *AblyProvider) Schema(ctx context.Context, req provider.SchemaRequest, r
 				Description: "The Ably Control API URL. Can also be set via the `ABLY_URL` environment variable. Defaults to the production API.",
 				Optional:    true,
 			},
+			"retry_max": schema.Int64Attribute{
+				Description: "Maximum number of times a failed Control API request is retried (on 5xx and connection errors; 4xx responses are never retried). Set to 0 to disable retries. Can also be set via the `ABLY_RETRY_MAX` environment variable. Defaults to 2.",
+				Optional:    true,
+			},
+			"retry_wait_min_seconds": schema.Int64Attribute{
+				Description: "Minimum wait, in seconds, between retries. This is the base for the exponential backoff. Can also be set via the `ABLY_RETRY_WAIT_MIN_SECONDS` environment variable. Defaults to 2.",
+				Optional:    true,
+			},
+			"retry_wait_max_seconds": schema.Int64Attribute{
+				Description: "Maximum wait, in seconds, between retries, capping the exponential backoff. Can also be set via the `ABLY_RETRY_WAIT_MAX_SECONDS` environment variable. Defaults to 60.",
+				Optional:    true,
+			},
 		},
 	}
 }
 
 // AblyProviderData contains configuration data for the Ably provider.
 type AblyProviderData struct {
-	Token types.String `tfsdk:"token"`
-	Url   types.String `tfsdk:"url"`
+	Token               types.String `tfsdk:"token"`
+	Url                 types.String `tfsdk:"url"`
+	RetryMax            types.Int64  `tfsdk:"retry_max"`
+	RetryWaitMinSeconds types.Int64  `tfsdk:"retry_wait_min_seconds"`
+	RetryWaitMaxSeconds types.Int64  `tfsdk:"retry_wait_max_seconds"`
 }
 
 func (p *AblyProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -122,7 +140,55 @@ func (p *AblyProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	if url == "" {
 		url = controlAPIDefaultURL
 	}
-	c := control.NewClient(token)
+	// Resolve optional retry tuning. Each attribute falls back to an
+	// environment variable, then to the control client's own defaults.
+	var opts []control.ClientOption
+	if n, ok, err := resolveRetryInt(config.RetryMax, "retry_max", "ABLY_RETRY_MAX"); err != nil {
+		resp.Diagnostics.AddError("Invalid retry configuration", err.Error())
+		return
+	} else if ok {
+		opts = append(opts, control.WithRetryMax(n))
+	}
+
+	waitMin, waitMinSet, err := resolveRetryInt(config.RetryWaitMinSeconds, "retry_wait_min_seconds", "ABLY_RETRY_WAIT_MIN_SECONDS")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid retry configuration", err.Error())
+		return
+	}
+	if waitMinSet {
+		opts = append(opts, control.WithRetryWaitMin(time.Duration(waitMin)*time.Second))
+	}
+
+	waitMax, waitMaxSet, err := resolveRetryInt(config.RetryWaitMaxSeconds, "retry_wait_max_seconds", "ABLY_RETRY_WAIT_MAX_SECONDS")
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid retry configuration", err.Error())
+		return
+	}
+	if waitMaxSet {
+		opts = append(opts, control.WithRetryWaitMax(time.Duration(waitMax)*time.Second))
+	}
+
+	// Guard against an inverted backoff window. go-retryablehttp silently caps
+	// every wait at the max, so a minimum above the maximum would quietly
+	// discard the configured minimum. Compare effective values, falling back to
+	// the client defaults for whichever bound wasn't set.
+	effectiveMin := waitMin
+	if !waitMinSet {
+		effectiveMin = int(control.DefaultRetryWaitMin / time.Second)
+	}
+	effectiveMax := waitMax
+	if !waitMaxSet {
+		effectiveMax = int(control.DefaultRetryWaitMax / time.Second)
+	}
+	if effectiveMin > effectiveMax {
+		resp.Diagnostics.AddError(
+			"Invalid retry configuration",
+			fmt.Sprintf("retry_wait_min_seconds (%d) must not exceed retry_wait_max_seconds (%d).", effectiveMin, effectiveMax),
+		)
+		return
+	}
+
+	c := control.NewClient(token, opts...)
 	c.BaseURL = url
 	c.UserAgent += " terraform-provider-ably/" + p.version
 
@@ -148,6 +214,31 @@ func (p *AblyProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 
 	p.accountID = me.Account.ID
 	p.configured = true
+}
+
+// resolveRetryInt resolves an optional non-negative integer provider
+// attribute, falling back to an environment variable when the config value is
+// null. It returns ok=false when neither is set, leaving the control client's
+// own default in place. Validation errors name the source the value came from,
+// the provider attribute (attrName) or the environment variable (envVar).
+func resolveRetryInt(attr types.Int64, attrName, envVar string) (value int, ok bool, err error) {
+	source := attrName
+	switch {
+	case !attr.IsNull() && !attr.IsUnknown():
+		value = int(attr.ValueInt64())
+	case os.Getenv(envVar) != "":
+		source = envVar
+		value, err = strconv.Atoi(os.Getenv(envVar))
+		if err != nil {
+			return 0, false, fmt.Errorf("%s must be an integer, got %q", envVar, os.Getenv(envVar))
+		}
+	default:
+		return 0, false, nil
+	}
+	if value < 0 {
+		return 0, false, fmt.Errorf("%s must not be negative, got %d", source, value)
+	}
+	return value, true, nil
 }
 
 // Resources - Gets the resources that this provider provides

--- a/internal/provider/provider_unit_test.go
+++ b/internal/provider/provider_unit_test.go
@@ -1,0 +1,61 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestResolveRetryInt(t *testing.T) {
+	const attrName, envVar = "retry_max", "ABLY_RETRY_MAX"
+
+	tests := []struct {
+		name      string
+		attr      types.Int64
+		env       string // "" means unset
+		wantValue int
+		wantOk    bool
+		errSubstr string // "" means no error expected
+	}{
+		{name: "attribute set", attr: types.Int64Value(3), wantValue: 3, wantOk: true},
+		{name: "attribute zero", attr: types.Int64Value(0), wantValue: 0, wantOk: true},
+		{name: "unset falls through", attr: types.Int64Null(), wantOk: false},
+		{name: "unknown falls through", attr: types.Int64Unknown(), wantOk: false},
+		{name: "env fallback", attr: types.Int64Null(), env: "5", wantValue: 5, wantOk: true},
+		{name: "attribute wins over env", attr: types.Int64Value(2), env: "9", wantValue: 2, wantOk: true},
+		{name: "non-integer env", attr: types.Int64Null(), env: "nope", errSubstr: envVar},
+		{name: "negative attribute names attribute", attr: types.Int64Value(-1), errSubstr: attrName},
+		{name: "negative env names env var", attr: types.Int64Null(), env: "-1", errSubstr: envVar},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				t.Setenv(envVar, tt.env)
+			}
+
+			value, ok, err := resolveRetryInt(tt.attr, attrName, envVar)
+
+			if tt.errSubstr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Fatalf("expected error to mention %q, got %q", tt.errSubstr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tt.wantOk {
+				t.Fatalf("ok: got %v, want %v", ok, tt.wantOk)
+			}
+			if ok && value != tt.wantValue {
+				t.Fatalf("value: got %d, want %d", value, tt.wantValue)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We added retries but I think this has had a knock-on impact on the staging site since it was introduced. Reduce the number of retries, with a greater possible retry wait between each one.

Also make them configurable at the Terraform provider level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limits and backoff timing for Control API requests.
  * Added provider settings for maximum retries and minimum/maximum retry wait times.
  * Added environment-variable support for retry configuration.

* **Bug Fixes**
  * Reduced default retries for server and connection errors from four attempts to two.

* **Documentation**
  * Documented the new retry configuration options, defaults, and environment-variable overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->