### PR TITLE
Reduce concurrency in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: check
+  cancel-in-progress: false
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.23, 1.24]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -30,10 +26,10 @@ jobs:
           submodules: 'recursive'
           persist-credentials: false
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: 'go.mod'
 
       - name: Download Packages
         run: go get -t -v
@@ -48,6 +44,10 @@ jobs:
         run: |
           mkdir bin
           go build -v -o bin
+
+      - name: Test Control API client
+        working-directory: control
+        run: go test -v ./...
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e

--- a/control/go.mod
+++ b/control/go.mod
@@ -1,6 +1,8 @@
 module github.com/ably/terraform-provider-ably/control
 
-go 1.24.0
+go 1.26.0
+
+toolchain go1.26.5
 
 require (
 	github.com/hashicorp/go-retryablehttp v0.7.8

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ably/terraform-provider-ably
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.1
+toolchain go1.26.5
 
 require (
 	github.com/ably/terraform-provider-ably/control v0.0.0


### PR DESCRIPTION
Makes a few small changes to reduce the amount we're smashing the staging site. See commits for detail.

- **Upgrade to latest Go version**
- **Reduce CI concurrency**
- **Only test latest Go version**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated Go test execution across the control components.
  * Improved workflow concurrency handling to prevent overlapping checks from being canceled.

* **Chores**
  * Updated the project’s Go toolchain requirements to Go 1.26.0, using Go 1.26.5 for builds and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->