### PR TITLE
exporter: generate Terraform config from an existing Ably account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@
 # a draft GitHub Release. The Terraform Registry webhook fires when the
 # draft is published.
 #
+# The same run attaches the account exporter (cmd/ably-exporter, see EXPORTER.md)
+# as ably-exporter_<version>_<os>_<arch>.zip assets, versioned with the provider.
+# They are excluded from the provider's SHA256SUMS, which is what the Registry
+# verifies against.
+#
 # Control releases are notes-only (no binaries). The Go module proxy
 # indexes new versions from the git tag automatically. Release notes
 # are scoped to PRs that touch control/ paths.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.tfstate*
 .terraform.lock.hcl
 terraform-provider-ably
+dist
+bin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,13 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
     - go mod tidy
 builds:
-- env:
+- id: provider
+  env:
     # goreleaser does not work with CGO, it could also complicate
     # usage by users in CI/CD systems like Terraform Cloud where
     # they are unable to install libraries.
@@ -29,10 +31,48 @@ builds:
     - goos: darwin
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
+# The account exporter (see EXPORTER.md). Released alongside the provider so the
+# versions match. It is a CLI rather than a plugin, so it skips the full provider
+# platform matrix and stays out of the SHA256SUMS the Registry consumes (see
+# checksum below).
+- id: exporter
+  main: ./cmd/ably-exporter
+  binary: ably-exporter
+  env:
+    - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+    - -trimpath
+  ldflags:
+    - '-s -w -X main.VERSION={{.Version}}'
+  goos:
+    - windows
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - arm64
 archives:
-- format: zip
+- id: provider
+  ids:
+    - provider
+  formats:
+    - zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+- id: exporter
+  ids:
+    - exporter
+  formats:
+    - zip
+  name_template: 'ably-exporter_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  files:
+    - EXPORTER.md
+    - LICENSE
 checksum:
+  # Provider artifacts only: the Registry reads this file to verify the provider
+  # archives, and has no reason to expect exporter entries.
+  ids:
+    - provider
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
@@ -41,7 +81,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,22 @@ Step-by-step runbooks are in `DEVELOPMENT.md`:
 
 and the pipeline details are in `codegen/README.md`.
 
+## The account exporter
+
+`cmd/ably-exporter` (package `internal/exporter`) generates Terraform config for
+an existing account. It drives the provider in-process over protocol v6, so
+schema changes need no work here, but two things do:
+
+- **A new integration rule** needs a line in `RuleTypeResources`
+  (`internal/provider/rule_types.go`) mapping its `ruleType` to the resource type.
+  `TestRuleTypeResources` catches a missing entry.
+- **A new family of resources** needs a lister in `internal/exporter/discover.go`
+  and its type in `SupportedResourceTypes`.
+  `TestSupportedResourceTypesCoverage` catches a gap.
+
+`EXPORTER.md` covers the design, including the validate-and-repair pass for
+provider validators the protocol schema doesn't expose.
+
 ## Things that will bite you (learned the hard way)
 
 - **Stale `dev_overrides`.** A `dev_overrides` block in `~/.terraformrc` takes

--- a/EXPORTER.md
+++ b/EXPORTER.md
@@ -1,0 +1,144 @@
+# Exporting an existing Ably account
+
+`cmd/ably-exporter` generates Terraform configuration for the resources already
+in an Ably account, so an account built by hand can be brought under Terraform
+without writing the config yourself.
+
+It needs an account token and nothing else. Every Control API call it makes is a
+read.
+
+```sh
+export ABLY_ACCOUNT_TOKEN=...
+make export-account                 # writes ./ably-export
+cd ably-export
+terraform init
+terraform plan                      # should report only the imports
+```
+
+`imports.tf` adopts the resources into state. Delete it once `terraform apply`
+has run the imports.
+
+## Getting it
+
+Each provider release carries an `ably-exporter_<version>_<os>_<arch>.zip` asset
+for Linux, macOS and Windows on amd64 and arm64, so the exporter matches the
+provider version it generates config for.
+
+The exporter is not listed in the release's `SHA256SUMS`. That file is what the
+Terraform Registry verifies the provider against.
+
+To build from a checkout:
+
+```sh
+make exporter                       # writes ./bin/ably-exporter
+```
+
+## What it writes
+
+```
+ably-export/
+  provider.tf          required_providers and the provider block
+  app_<name>.tf        one file per app: the app and everything inside it
+  variables.tf         only with -secrets=vars
+  imports.tf           import blocks, unless -imports=false
+```
+
+Labels come from Ably names, so `ably_app.chat_service` rather than an opaque ID.
+Attributes holding another resource's ID are written as references
+(`app_id = ably_app.chat_service.id`), so the config carries its own dependencies
+and is portable between accounts.
+
+Files holding credentials are written `0600`.
+
+## Flags
+
+| Flag | Default | What it does |
+| --- | --- | --- |
+| `-token` | `$ABLY_ACCOUNT_TOKEN` | Account token. |
+| `-out` | `./ably-export` | Output directory. |
+| `-app` | all apps | Only export this app, by ID or name. Repeatable, or comma-separated. |
+| `-secrets` | `inline` | `inline`, `vars` or `omit`. See below. |
+| `-imports` | `true` | Generate `import` blocks. |
+| `-single-file` | `false` | Write everything to `main.tf`. |
+| `-provider-version` | `~> 1.0` | Version constraint in `required_providers`. Empty omits it. |
+| `-force` | `false` | Write into a directory that already holds `.tf` files. Clears files a previous export wrote; leaves hand-written ones alone. |
+
+## Secrets
+
+- `-secrets=inline` (default) writes what the API returned. Accurate and plans
+  clean, but the output holds credentials.
+- `-secrets=vars` replaces sensitive values with references to sensitive
+  variables declared in `variables.tf`. Safe to commit, but you supply the values
+  before it will apply.
+- `-secrets=omit` leaves sensitive attributes out, with a comment where each one
+  would have gone.
+
+Whichever you pick, the exporter reports how many sensitive values it touched.
+
+## Before you apply
+
+- **Some values cannot be exported.** The Control API accepts them on write and
+  never returns them: `ably_app.fcm_key` and the APNs credentials, AWS
+  `secret_access_key`, Kafka SASL credentials, Pulsar `tls_trust_certs`. Where
+  such a value is required, the exporter writes a `# TODO` (or a variable, under
+  `-secrets=vars`) and lists it in the summary, rather than writing the empty
+  string the API hands back and wiping the live credential on apply. Optional ones
+  are simply absent and will be cleared unless you fill them in. Read the plan.
+- **Revoked API keys are skipped.** The provider reads them as gone, so exporting
+  one gives config for a resource that isn't there.
+- **Unsupported rule types are skipped with a warning**, named by rule ID and
+  type rather than dropped silently.
+- **`# TODO` means something needs you.** Either a value the API withholds, or
+  config the provider rejected. Both are listed in the summary.
+
+## How it keeps up with the provider
+
+The exporter carries no copy of the schema. It runs the provider in-process and
+drives it over the protocol-v6 RPCs Terraform uses:
+
+1. `GetProviderSchema` for the resource schemas.
+2. `ImportResourceState` and `ReadResource` per resource, which is what
+   `terraform import` does, so the state rendered is the state Terraform would
+   hold.
+3. `ValidateResourceConfig` on the config it is about to write.
+
+So **a new attribute on an existing resource needs no change to the exporter**,
+and what it writes is what the provider says it will accept.
+
+Two things do need a change, and both fail loudly if missed:
+
+- **A new integration rule** needs a line in `RuleTypeResources`
+  (`internal/provider/rule_types.go`) mapping its `ruleType` to its resource type.
+  Every rule arrives from the same `GET /apps/{id}/rules`, so that mapping is the
+  only way to tell which resource owns one. `TestRuleTypeResources` catches a
+  missing entry.
+- **A new family of resources** (not an app, key, namespace, queue or rule) needs
+  a lister in `internal/exporter/discover.go` and its type in
+  `SupportedResourceTypes`. `TestSupportedResourceTypesCoverage` catches a gap.
+
+### The validate-and-repair pass
+
+Validators are not part of the protocol schema, so the exporter asks about them
+instead. `ably_namespace` is the live example: it has an `identified` attribute
+and a deprecated `authenticated` alias that conflict in config, and a read
+returns both.
+
+The exporter validates what it generated and, when the provider objects, removes
+the attribute and asks again. It only ever removes **deprecated** attributes,
+which have a modern equivalent carrying the same value. Anything else is left as
+the API returned it and reported with a `TODO`: a rejected value is a real
+disagreement between provider and API, and deleting config to satisfy a validator
+would hide it. Every removal is reported.
+
+That handles new conflicts and new deprecations without any change here.
+
+## Testing
+
+`make test` covers the exporter against a read-only in-process fake Control API,
+with no credentials and no network. It checks the generated HCL parses, that
+computed attributes never appear (Terraform rejects those), that references and
+import IDs are right, all three secrets modes, withheld required values, stale
+file cleanup, file permissions, and the repair pass.
+
+For an end-to-end check, export a real account and run `terraform plan`: a
+correct export reports imports and no other changes.

--- a/Makefile
+++ b/Makefile
@@ -84,4 +84,15 @@ endif
 	if [ -f codegen/spec-fixes.patch ]; then git apply codegen/spec-fixes.patch; fi
 	$(MAKE) generate
 
-.PHONY: build release install test testacc generate refresh-spec
+# Build the account exporter, which generates Terraform config for the resources
+# already in an Ably account. See EXPORTER.md.
+exporter:
+	go build -ldflags="-X main.VERSION=${VERSION}" -o ./bin/ably-exporter ./cmd/ably-exporter
+
+# Export an account into ./ably-export. Needs ABLY_ACCOUNT_TOKEN; only reads.
+# Extra flags via EXPORTARGS, e.g.
+# make export-account EXPORTARGS="-app my-app -secrets vars".
+export-account: exporter
+	./bin/ably-exporter $(EXPORTARGS)
+
+.PHONY: build release install test testacc generate refresh-spec exporter export-account

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ resource "ably_queue" "example_queue" {
 }
 ```
 
+## Exporting an existing account
+
+If your account was built by hand, you don't have to write its configuration. The
+exporter walks an account and generates the Terraform config and `import` blocks
+for everything in it:
+
+```sh
+export ABLY_ACCOUNT_TOKEN=...
+make export-account
+cd ably-export && terraform init && terraform plan
+```
+
+It only reads from the Control API. Prebuilt `ably-exporter` binaries ship as
+assets on each provider release. See [EXPORTER.md](EXPORTER.md) for the flags, how
+secrets are handled, and what it cannot recover.
+
 ## Dependencies
 
 This provider uses the [Ably Control API](https://ably.com/docs/api/control-api) via the [`control`](control/) Go client module in this repository, which replaced the standalone [ably-control-go](https://github.com/ably/ably-control-go) SDK.

--- a/cmd/ably-exporter/main.go
+++ b/cmd/ably-exporter/main.go
@@ -1,0 +1,216 @@
+// Command ably-exporter generates Terraform configuration for the resources in an
+// Ably account. It needs an account token and nothing else:
+//
+//	ABLY_ACCOUNT_TOKEN=... go run ./cmd/ably-exporter -out ./ably
+//
+// Every Control API call it makes is a read.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ably/terraform-provider-ably/internal/exporter"
+)
+
+// hiddenFlags are accepted but left out of the usage text. -url points the
+// exporter at a different Control API, which only Ably's own environments need.
+var hiddenFlags = map[string]bool{"url": true}
+
+// VERSION is reported in the exporter's User-Agent. Overridden at release time
+// with -ldflags="-X main.VERSION=x.y.z", as the provider binary is.
+var VERSION = "1.0.0"
+
+// appList collects a repeatable -app flag, also accepting a comma-separated
+// list in one go.
+type appList []string
+
+func (a *appList) String() string { return strings.Join(*a, ",") }
+
+func (a *appList) Set(value string) error {
+	before := len(*a)
+	for part := range strings.SplitSeq(value, ",") {
+		if part = strings.TrimSpace(part); part != "" {
+			*a = append(*a, part)
+		}
+	}
+	// An -app that parses to nothing would widen the export to the whole
+	// account. Catches -app with an unset shell variable.
+	if len(*a) == before {
+		return fmt.Errorf("no app named in %q", value)
+	}
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "ably-exporter: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+// options are the flag values, gathered so that flag registration can be shared
+// with the tests.
+type options struct {
+	token           *string
+	url             *string
+	out             *string
+	secrets         *string
+	imports         *bool
+	singleFile      *bool
+	providerVersion *string
+	force           *bool
+	showVersion     *bool
+}
+
+// registerFlags defines the command line, writing app filters into apps.
+func registerFlags(apps *appList) (*flag.FlagSet, *options) {
+	flags := flag.NewFlagSet("ably-exporter", flag.ContinueOnError)
+	opts := &options{
+		token: flags.String("token", "", "Ably account token. Defaults to $ABLY_ACCOUNT_TOKEN."),
+		url:   flags.String("url", "", "Control API URL. Defaults to $ABLY_URL."),
+		out:   flags.String("out", "./ably-export", "Directory to write the generated configuration into."),
+		secrets: flags.String("secrets", string(exporter.SecretsInline),
+			"What to do with sensitive values: inline (write them), vars (reference sensitive variables) or omit (leave them out)."),
+		imports:    flags.Bool("imports", true, "Generate import blocks alongside the configuration."),
+		singleFile: flags.Bool("single-file", false, "Write everything to main.tf instead of one file per app."),
+		providerVersion: flags.String("provider-version", exporter.DefaultProviderVersion,
+			"Version constraint for the generated required_providers block. Empty omits it."),
+		force:       flags.Bool("force", false, "Write into the output directory even if it already contains .tf files."),
+		showVersion: flags.Bool("version", false, "Print the exporter version and exit."),
+	}
+	flags.Var(apps, "app", "Only export this app, by ID or name. Repeatable, or comma-separated.")
+
+	flags.SetOutput(os.Stderr)
+	flags.Usage = func() { fmt.Fprint(os.Stderr, usageText(flags)) }
+	return flags, opts
+}
+
+func run() error {
+	var apps appList
+	flags, opts := registerFlags(&apps)
+
+	if err := flags.Parse(os.Args[1:]); err != nil {
+		if err == flag.ErrHelp {
+			return nil
+		}
+		return err
+	}
+
+	if *opts.showVersion {
+		fmt.Println("ably-exporter " + VERSION)
+		return nil
+	}
+
+	secretMode, err := exporter.ParseSecretMode(*opts.secrets)
+	if err != nil {
+		return err
+	}
+
+	accountToken := *opts.token
+	if accountToken == "" {
+		accountToken = os.Getenv("ABLY_ACCOUNT_TOKEN")
+	}
+	if accountToken == "" {
+		return fmt.Errorf("no account token: pass -token or set ABLY_ACCOUNT_TOKEN")
+	}
+
+	controlURL := *opts.url
+	if controlURL == "" {
+		controlURL = os.Getenv("ABLY_URL")
+	}
+
+	result, err := exporter.Run(context.Background(), exporter.Config{
+		Token:           accountToken,
+		URL:             controlURL,
+		Apps:            apps,
+		Secrets:         secretMode,
+		Imports:         *opts.imports,
+		SingleFile:      *opts.singleFile,
+		ProviderVersion: *opts.providerVersion,
+		Version:         VERSION,
+	})
+	if err != nil {
+		return err
+	}
+
+	if err := exporter.WriteFiles(*opts.out, result, *opts.force); err != nil {
+		return err
+	}
+
+	report(result, *opts.out, secretMode)
+	return nil
+}
+
+// usageText builds the usage text, skipping hiddenFlags. It walks the flag set
+// rather than listing flags by hand so it can't drift from what is registered.
+func usageText(flags *flag.FlagSet) string {
+	var buf strings.Builder
+	buf.WriteString("Usage: ably-exporter [flags]\n\n" +
+		"Generates Terraform configuration for the resources in an Ably account.\n" +
+		"Only reads from the Control API.\n\nFlags:\n")
+
+	flags.VisitAll(func(f *flag.Flag) {
+		if hiddenFlags[f.Name] {
+			return
+		}
+		name, usage := flag.UnquoteUsage(f)
+		if name != "" {
+			name = " " + name
+		}
+		fmt.Fprintf(&buf, "  -%s%s\n    \t%s", f.Name, name, usage)
+		// Defaults that carry information, so not "" or false.
+		if f.DefValue != "" && f.DefValue != "false" {
+			fmt.Fprintf(&buf, " (default %s)", f.DefValue)
+		}
+		buf.WriteString("\n")
+	})
+	return buf.String()
+}
+
+// report prints a summary to stderr, leaving stdout free to pipe.
+func report(result *exporter.Result, out string, secrets exporter.SecretMode) {
+	fmt.Fprint(os.Stderr, result.Summary())
+	fmt.Fprintf(os.Stderr, "\nWritten to %s:\n", out)
+	for _, file := range result.Files {
+		fmt.Fprintf(os.Stderr, "  %s\n", file.Name)
+	}
+
+	if len(result.Warnings) > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d warnings:\n", len(result.Warnings))
+		for _, warning := range result.Warnings {
+			fmt.Fprintf(os.Stderr, "  %s\n", warning)
+		}
+	}
+
+	if len(result.Missing) > 0 {
+		fmt.Fprintf(os.Stderr, "\n%d required values are missing because the Control API does not return them:\n", len(result.Missing))
+		for _, missing := range result.Missing {
+			fmt.Fprintf(os.Stderr, "  %s\n", missing)
+		}
+	}
+
+	if len(result.Sensitive) > 0 {
+		switch secrets {
+		case exporter.SecretsInline:
+			fmt.Fprintf(os.Stderr, "\n%d sensitive values were written into the output. Treat these files as secrets.\n",
+				len(result.Sensitive))
+		case exporter.SecretsVars:
+			if result.Variables {
+				fmt.Fprintf(os.Stderr, "\n%d sensitive values were replaced with variables. Fill in variables.tf before applying.\n",
+					len(result.Sensitive))
+			} else {
+				fmt.Fprintf(os.Stderr, "\n%d sensitive values were left out: none could be replaced with a variable. See the comments in the output.\n",
+					len(result.Sensitive))
+			}
+		case exporter.SecretsOmit:
+			fmt.Fprintf(os.Stderr, "\n%d sensitive values were left out. The config will not apply cleanly until you add them.\n",
+				len(result.Sensitive))
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "\nNext: cd %s && terraform init && terraform plan\n", out)
+}

--- a/cmd/ably-exporter/main_test.go
+++ b/cmd/ably-exporter/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"flag"
+	"strings"
+	"testing"
+)
+
+// TestUsageTextHidesInternalFlags guards the customer-facing help text. -url
+// points the exporter at a different Control API, which only Ably's own
+// environments need, so it must not appear.
+func TestUsageTextHidesInternalFlags(t *testing.T) {
+	text := usageText(exporterFlags())
+
+	for _, unwanted := range []string{"-url", "ABLY_URL", "production"} {
+		if strings.Contains(text, unwanted) {
+			t.Errorf("usage mentions %q:\n%s", unwanted, text)
+		}
+	}
+
+	// The flags customers do use have to survive the filter.
+	for _, wanted := range []string{"-token", "-out", "-app", "-secrets", "-imports", "-force"} {
+		if !strings.Contains(text, wanted) {
+			t.Errorf("usage is missing %s:\n%s", wanted, text)
+		}
+	}
+}
+
+// TestHiddenFlagsAreRegistered checks every hidden flag exists. A typo would
+// hide nothing and go unnoticed.
+func TestHiddenFlagsAreRegistered(t *testing.T) {
+	flags := exporterFlags()
+	for name := range hiddenFlags {
+		if flags.Lookup(name) == nil {
+			t.Errorf("hiddenFlags names %q, which is not a registered flag", name)
+		}
+	}
+}
+
+func TestAppListRejectsEmptyValues(t *testing.T) {
+	var apps appList
+	if err := apps.Set(""); err == nil {
+		t.Error("an empty -app should fail rather than export the whole account")
+	}
+	if err := apps.Set(" , "); err == nil {
+		t.Error("an -app of separators should fail")
+	}
+	if err := apps.Set("one, two"); err != nil {
+		t.Fatalf("Set: %s", err)
+	}
+	if got := apps.String(); got != "one,two" {
+		t.Errorf("apps = %q, want one,two", got)
+	}
+}
+
+// exporterFlags builds the flag set the way run does, for tests that inspect it.
+func exporterFlags() *flag.FlagSet {
+	var apps appList
+	flags, _ := registerFlags(&apps)
+	return flags
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.26.5
 
 require (
 	github.com/ably/terraform-provider-ably/control v0.0.0
+	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
@@ -43,7 +44,6 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/hc-install v0.9.4 // indirect
-	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect

--- a/internal/exporter/bridge.go
+++ b/internal/exporter/bridge.go
@@ -1,0 +1,250 @@
+package exporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/ably/terraform-provider-ably/internal/provider"
+)
+
+// terraformVersion is the version the bridge reports to the provider. It only
+// ever reaches the provider's User-Agent and logs; nothing gates on it.
+const terraformVersion = "1.9.0"
+
+// errResourceGone reports that a resource vanished between being listed and
+// being read. Accounts change under us, so this is expected, not exceptional.
+var errResourceGone = errors.New("resource no longer exists")
+
+// bridge runs the provider in-process and drives it over the protocol-v6 RPCs
+// Terraform uses: GetProviderSchema, ConfigureProvider, ImportResourceState,
+// ReadResource and ValidateResourceConfig.
+//
+// Using the protocol rather than the provider's Go types means schemas,
+// sensitivity and the API-to-state mapping all come from the provider as
+// compiled, and the state rendered to HCL is what Terraform would hold after
+// terraform import.
+type bridge struct {
+	server    tfprotov6.ProviderServer
+	provider  *tfprotov6.Schema
+	resources map[string]*tfprotov6.Schema
+}
+
+// newBridge starts the provider and reads its schemas.
+func newBridge(ctx context.Context, version string) (*bridge, error) {
+	server := providerserver.NewProtocol6(provider.New(version)())()
+
+	resp, err := server.GetProviderSchema(ctx, &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("reading provider schema: %w", err)
+	}
+	if _, err := splitDiagnostics(resp.Diagnostics); err != nil {
+		return nil, fmt.Errorf("reading provider schema: %w", err)
+	}
+
+	return &bridge{
+		server:    server,
+		provider:  resp.Provider,
+		resources: resp.ResourceSchemas,
+	}, nil
+}
+
+// configure configures the provider with an account token and Control API URL.
+// The config object is built from the provider's own schema, so attributes added
+// to the provider block later need no change here.
+func (b *bridge) configure(ctx context.Context, token, url string) error {
+	configType := b.provider.ValueType()
+	object, ok := configType.(tftypes.Object)
+	if !ok {
+		return fmt.Errorf("provider config type is %T, expected an object", configType)
+	}
+
+	attributes := map[string]tftypes.Value{}
+	for name, attrType := range object.AttributeTypes {
+		switch {
+		case name == "token":
+			attributes[name] = tftypes.NewValue(attrType, token)
+		case name == "url" && url != "":
+			attributes[name] = tftypes.NewValue(attrType, url)
+		default:
+			attributes[name] = tftypes.NewValue(attrType, nil)
+		}
+	}
+
+	config, err := tfprotov6.NewDynamicValue(configType, tftypes.NewValue(configType, attributes))
+	if err != nil {
+		return fmt.Errorf("encoding provider config: %w", err)
+	}
+
+	resp, err := b.server.ConfigureProvider(ctx, &tfprotov6.ConfigureProviderRequest{
+		TerraformVersion: terraformVersion,
+		Config:           &config,
+	})
+	if err != nil {
+		return fmt.Errorf("configuring provider: %w", err)
+	}
+	if _, err := splitDiagnostics(resp.Diagnostics); err != nil {
+		return fmt.Errorf("configuring provider: %w", err)
+	}
+	return nil
+}
+
+// schema returns the schema for a resource type.
+func (b *bridge) schema(resourceType string) (*tfprotov6.Schema, error) {
+	schema, ok := b.resources[resourceType]
+	if !ok {
+		return nil, fmt.Errorf("provider does not serve resource type %q", resourceType)
+	}
+	return schema, nil
+}
+
+// read imports a resource by its import ID and reads it, returning the resulting
+// state. These are the calls terraform import makes, so the import IDs written
+// into imports.tf are ones the exporter has just proved work.
+func (b *bridge) read(ctx context.Context, resourceType, importID string) (tftypes.Value, []string, error) {
+	schema, err := b.schema(resourceType)
+	if err != nil {
+		return tftypes.Value{}, nil, err
+	}
+	stateType := schema.ValueType()
+
+	var warnings []string
+
+	importResp, err := b.server.ImportResourceState(ctx, &tfprotov6.ImportResourceStateRequest{
+		TypeName: resourceType,
+		ID:       importID,
+	})
+	if err != nil {
+		return tftypes.Value{}, warnings, fmt.Errorf("importing %s %q: %w", resourceType, importID, err)
+	}
+	importWarnings, err := splitDiagnostics(importResp.Diagnostics)
+	warnings = append(warnings, importWarnings...)
+	if err != nil {
+		return tftypes.Value{}, warnings, fmt.Errorf("importing %s %q: %w", resourceType, importID, err)
+	}
+	if len(importResp.ImportedResources) == 0 {
+		return tftypes.Value{}, warnings, fmt.Errorf("importing %s %q: provider returned no state", resourceType, importID)
+	}
+	imported := importResp.ImportedResources[0]
+
+	readResp, err := b.server.ReadResource(ctx, &tfprotov6.ReadResourceRequest{
+		TypeName:     resourceType,
+		CurrentState: imported.State,
+		Private:      imported.Private,
+	})
+	if err != nil {
+		return tftypes.Value{}, warnings, fmt.Errorf("reading %s %q: %w", resourceType, importID, err)
+	}
+	readWarnings, err := splitDiagnostics(readResp.Diagnostics)
+	warnings = append(warnings, readWarnings...)
+	if err != nil {
+		return tftypes.Value{}, warnings, fmt.Errorf("reading %s %q: %w", resourceType, importID, err)
+	}
+	if readResp.NewState == nil {
+		return tftypes.Value{}, warnings, errResourceGone
+	}
+
+	state, err := readResp.NewState.Unmarshal(stateType)
+	if err != nil {
+		return tftypes.Value{}, warnings, fmt.Errorf("decoding %s %q state: %w", resourceType, importID, err)
+	}
+	// The provider signals "not found" by removing the resource from state,
+	// which reaches us as a null object.
+	if state.IsNull() {
+		return tftypes.Value{}, warnings, errResourceGone
+	}
+
+	return state, warnings, nil
+}
+
+// validate asks the provider whether it would accept a configuration. It is how
+// the exporter learns about anything the provider enforces with validators
+// rather than schema flags, conflicting attributes in particular.
+func (b *bridge) validate(ctx context.Context, resourceType string, config tftypes.Value) ([]*tfprotov6.Diagnostic, error) {
+	schema, err := b.schema(resourceType)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded, err := tfprotov6.NewDynamicValue(schema.ValueType(), config)
+	if err != nil {
+		return nil, fmt.Errorf("encoding %s config: %w", resourceType, err)
+	}
+
+	resp, err := b.server.ValidateResourceConfig(ctx, &tfprotov6.ValidateResourceConfigRequest{
+		TypeName: resourceType,
+		Config:   &encoded,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Diagnostics, nil
+}
+
+// hasAttribute reports whether a resource schema has a top-level attribute.
+func hasAttribute(schema *tfprotov6.Schema, name string) bool {
+	if schema == nil || schema.Block == nil {
+		return false
+	}
+	for _, attribute := range schema.Block.Attributes {
+		if attribute != nil && attribute.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// importID builds the import identifier for a resource. Resources inside an app
+// take "appID,id" (see ImportResource in the provider package), account-level
+// ones the bare ID. Keying off the app_id attribute rather than a hardcoded list
+// means a future account-level resource works untouched.
+func (b *bridge) importID(resourceType, appID, id string) (string, error) {
+	schema, err := b.schema(resourceType)
+	if err != nil {
+		return "", err
+	}
+	if hasAttribute(schema, "app_id") {
+		if appID == "" {
+			return "", fmt.Errorf("resource type %s is app-scoped but no app ID was given", resourceType)
+		}
+		return appID + "," + id, nil
+	}
+	return id, nil
+}
+
+// splitDiagnostics separates warnings from errors, returning the warning
+// messages and a single error covering every error diagnostic.
+func splitDiagnostics(diagnostics []*tfprotov6.Diagnostic) ([]string, error) {
+	var warnings []string
+	var errs []string
+
+	for _, diagnostic := range diagnostics {
+		if diagnostic == nil {
+			continue
+		}
+		message := diagnostic.Summary
+		if detail := strings.TrimSpace(diagnostic.Detail); detail != "" {
+			message += ": " + detail
+		}
+		if diagnostic.Attribute != nil {
+			message += fmt.Sprintf(" (at %s)", diagnostic.Attribute)
+		}
+
+		switch diagnostic.Severity {
+		case tfprotov6.DiagnosticSeverityError:
+			errs = append(errs, message)
+		default:
+			warnings = append(warnings, message)
+		}
+	}
+
+	if len(errs) > 0 {
+		return warnings, errors.New(strings.Join(errs, "; "))
+	}
+	return warnings, nil
+}

--- a/internal/exporter/config.go
+++ b/internal/exporter/config.go
@@ -1,0 +1,385 @@
+package exporter
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// maxRepairs bounds the validate-and-repair loop. Each pass drops one
+// attribute, and no real resource needs anything like this many.
+const maxRepairs = 8
+
+// configValue turns a resource's Terraform state into the configuration value a
+// user could have written for it: attributes the provider computes are nulled
+// out, at every level of nesting.
+//
+// This is the value the exporter validates and renders, rather than the raw
+// state, so what gets written is exactly what a user is allowed to write.
+func configValue(schema *tfprotov6.Schema, state tftypes.Value) (tftypes.Value, error) {
+	if schema == nil || schema.Block == nil {
+		return state, fmt.Errorf("resource has no schema")
+	}
+	return configBlock(schema.Block, state)
+}
+
+func configBlock(block *tfprotov6.SchemaBlock, value tftypes.Value) (tftypes.Value, error) {
+	if value.IsNull() || !value.IsKnown() {
+		return value, nil
+	}
+
+	attributes := map[string]tftypes.Value{}
+	if err := value.As(&attributes); err != nil {
+		return value, err
+	}
+
+	for _, attribute := range block.Attributes {
+		if attribute == nil {
+			continue
+		}
+		current, ok := attributes[attribute.Name]
+		if !ok {
+			continue
+		}
+
+		if isComputedOnly(attribute) || attribute.WriteOnly {
+			attributes[attribute.Name] = tftypes.NewValue(current.Type(), nil)
+			continue
+		}
+		if attribute.NestedType != nil {
+			nested, err := configNested(attribute.NestedType, current)
+			if err != nil {
+				return value, err
+			}
+			attributes[attribute.Name] = nested
+		}
+	}
+
+	for _, nestedBlock := range block.BlockTypes {
+		if nestedBlock == nil {
+			continue
+		}
+		current, ok := attributes[nestedBlock.TypeName]
+		if !ok {
+			continue
+		}
+		rebuilt, err := configCollection(current, func(element tftypes.Value) (tftypes.Value, error) {
+			return configBlock(nestedBlock.Block, element)
+		})
+		if err != nil {
+			return value, err
+		}
+		attributes[nestedBlock.TypeName] = rebuilt
+	}
+
+	return tftypes.NewValue(value.Type(), attributes), nil
+}
+
+func configNested(nested *tfprotov6.SchemaObject, value tftypes.Value) (tftypes.Value, error) {
+	object := &tfprotov6.SchemaBlock{Attributes: nested.Attributes}
+	if nested.Nesting == tfprotov6.SchemaObjectNestingModeSingle {
+		return configBlock(object, value)
+	}
+	return configCollection(value, func(element tftypes.Value) (tftypes.Value, error) {
+		return configBlock(object, element)
+	})
+}
+
+// configCollection applies transform to every element of a list, set, map or
+// single object, rebuilding the collection around the results.
+func configCollection(value tftypes.Value, transform func(tftypes.Value) (tftypes.Value, error)) (tftypes.Value, error) {
+	if value.IsNull() || !value.IsKnown() {
+		return value, nil
+	}
+
+	valueType := value.Type()
+	switch {
+	case valueType.Is(tftypes.List{}), valueType.Is(tftypes.Set{}), valueType.Is(tftypes.Tuple{}):
+		elements := []tftypes.Value{}
+		if err := value.As(&elements); err != nil {
+			return value, err
+		}
+		for index, element := range elements {
+			transformed, err := transform(element)
+			if err != nil {
+				return value, err
+			}
+			elements[index] = transformed
+		}
+		return tftypes.NewValue(valueType, elements), nil
+
+	// A single nested object or block arrives as an Object; transform it whole.
+	case valueType.Is(tftypes.Object{}):
+		return transform(value)
+
+	case valueType.Is(tftypes.Map{}):
+		elements := map[string]tftypes.Value{}
+		if err := value.As(&elements); err != nil {
+			return value, err
+		}
+		for key, element := range elements {
+			transformed, err := transform(element)
+			if err != nil {
+				return value, err
+			}
+			elements[key] = transformed
+		}
+		return tftypes.NewValue(valueType, elements), nil
+
+	default:
+		return value, nil
+	}
+}
+
+func isComputedOnly(attribute *tfprotov6.SchemaAttribute) bool {
+	return attribute.Computed && !attribute.Optional && !attribute.Required
+}
+
+// repairConfig asks the provider to validate a generated configuration and
+// removes redundant attributes the provider will not accept.
+//
+// This exists because validators are not part of the protocol schema: the
+// provider can reject a combination of attributes that nothing in the schema
+// warns about. ably_namespace is the case in hand. It has an `identified`
+// attribute and a deprecated `authenticated` alias which conflict in config,
+// and a read returns values for both.
+//
+// It only ever removes *deprecated* attributes. A deprecated attribute has a
+// modern equivalent carrying the same information, so taking it out loses
+// nothing. Anything else the provider objects to is left exactly as the Control
+// API returned it and reported instead: if the provider rejects a value, that is
+// a genuine disagreement between the provider and the API, and quietly deleting
+// the user's configuration to make the validator happy would hide it.
+//
+// It returns the config, notes describing what it removed, and notes describing
+// what it could not fix.
+func repairConfig(ctx context.Context, bridge *bridge, resourceType, label string, schema *tfprotov6.Schema, config tftypes.Value) (tftypes.Value, []string, []string) {
+	var dropped, unresolved []string
+
+	for range maxRepairs {
+		diagnostics, err := bridge.validate(ctx, resourceType, config)
+		if err != nil {
+			return config, dropped, append(unresolved, fmt.Sprintf(
+				"could not validate the generated config for %s.%s: %s", resourceType, label, err))
+		}
+
+		problems := errorDiagnostics(diagnostics)
+		if len(problems) == 0 {
+			return config, dropped, unresolved
+		}
+
+		path := chooseRedundant(schema, config, problems)
+		if path == nil {
+			return config, dropped, append(unresolved, fmt.Sprintf(
+				"the provider rejected the generated config for %s.%s, review it by hand: %s",
+				resourceType, label, strings.Join(summaries(problems), "; ")))
+		}
+
+		repaired, err := nullifyPath(config, path.Steps())
+		if err != nil {
+			return config, dropped, append(unresolved, fmt.Sprintf(
+				"could not drop %s from %s.%s: %s", formatPath(path), resourceType, label, err))
+		}
+		config = repaired
+		dropped = append(dropped, fmt.Sprintf("dropped the deprecated %s.%s.%s: %s",
+			resourceType, label, formatPath(path), firstSummary(problems, path)))
+	}
+
+	// The last pass may have fixed the last problem, so check before declaring
+	// failure. Report the outstanding diagnostics when it didn't: a bare "gave
+	// up" leaves nothing to act on.
+	diagnostics, err := bridge.validate(ctx, resourceType, config)
+	if err == nil {
+		problems := errorDiagnostics(diagnostics)
+		if len(problems) == 0 {
+			return config, dropped, unresolved
+		}
+		return config, dropped, append(unresolved, fmt.Sprintf(
+			"gave up repairing the generated config for %s.%s after %d attempts, review it by hand: %s",
+			resourceType, label, maxRepairs, strings.Join(summaries(problems), "; ")))
+	}
+	return config, dropped, append(unresolved, fmt.Sprintf(
+		"gave up repairing the generated config for %s.%s after %d attempts, and could not re-read why: %s",
+		resourceType, label, maxRepairs, err))
+}
+
+// chooseRedundant picks the next deprecated attribute to remove: one the
+// provider complained about, that a user could have set, and that currently
+// carries a value. Ties break on the path so a re-run makes the same choice.
+func chooseRedundant(schema *tfprotov6.Schema, config tftypes.Value, problems []*tfprotov6.Diagnostic) *tftypes.AttributePath {
+	var candidates []*tftypes.AttributePath
+
+	for _, problem := range problems {
+		if problem.Attribute == nil {
+			continue
+		}
+		attribute := attributeAtPath(schema, problem.Attribute.Steps())
+		if attribute == nil || !attribute.Deprecated || attribute.Required || !attribute.Optional {
+			continue
+		}
+		current, err := valueAtPath(config, problem.Attribute.Steps())
+		if err != nil || current.IsNull() {
+			continue
+		}
+		candidates = append(candidates, problem.Attribute)
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return formatPath(candidates[i]) < formatPath(candidates[j])
+	})
+	return candidates[0]
+}
+
+// attributeAtPath resolves an attribute path against a schema. It only follows
+// attribute names, which is as deep as validator diagnostics reach in practice.
+func attributeAtPath(schema *tfprotov6.Schema, steps []tftypes.AttributePathStep) *tfprotov6.SchemaAttribute {
+	if schema == nil || schema.Block == nil || len(steps) == 0 {
+		return nil
+	}
+
+	attributes := schema.Block.Attributes
+	for index, step := range steps {
+		name, ok := step.(tftypes.AttributeName)
+		if !ok {
+			return nil
+		}
+		var found *tfprotov6.SchemaAttribute
+		for _, attribute := range attributes {
+			if attribute != nil && attribute.Name == string(name) {
+				found = attribute
+				break
+			}
+		}
+		if found == nil {
+			return nil
+		}
+		if index == len(steps)-1 {
+			return found
+		}
+		if found.NestedType == nil {
+			return nil
+		}
+		attributes = found.NestedType.Attributes
+	}
+	return nil
+}
+
+// valueAtPath reads the value at an attribute path.
+func valueAtPath(value tftypes.Value, steps []tftypes.AttributePathStep) (tftypes.Value, error) {
+	if len(steps) == 0 {
+		return value, nil
+	}
+	name, ok := steps[0].(tftypes.AttributeName)
+	if !ok {
+		return value, fmt.Errorf("unsupported path step %T", steps[0])
+	}
+	if value.IsNull() || !value.IsKnown() {
+		return value, fmt.Errorf("no value at %s", name)
+	}
+
+	attributes := map[string]tftypes.Value{}
+	if err := value.As(&attributes); err != nil {
+		return value, err
+	}
+	child, ok := attributes[string(name)]
+	if !ok {
+		return value, fmt.Errorf("no attribute named %s", name)
+	}
+	return valueAtPath(child, steps[1:])
+}
+
+// nullifyPath returns a copy of value with the attribute at the given path set
+// to null.
+func nullifyPath(value tftypes.Value, steps []tftypes.AttributePathStep) (tftypes.Value, error) {
+	if len(steps) == 0 {
+		return tftypes.NewValue(value.Type(), nil), nil
+	}
+	name, ok := steps[0].(tftypes.AttributeName)
+	if !ok {
+		return value, fmt.Errorf("unsupported path step %T", steps[0])
+	}
+
+	attributes := map[string]tftypes.Value{}
+	if err := value.As(&attributes); err != nil {
+		return value, err
+	}
+	child, ok := attributes[string(name)]
+	if !ok {
+		return value, fmt.Errorf("no attribute named %s", name)
+	}
+
+	updated, err := nullifyPath(child, steps[1:])
+	if err != nil {
+		return value, err
+	}
+	attributes[string(name)] = updated
+
+	return tftypes.NewValue(value.Type(), attributes), nil
+}
+
+// formatPath renders an attribute path the way it is written in HCL, rather
+// than in the tftypes debug form.
+func formatPath(path *tftypes.AttributePath) string {
+	if path == nil {
+		return "(root)"
+	}
+
+	var buf strings.Builder
+	for _, step := range path.Steps() {
+		switch step := step.(type) {
+		case tftypes.AttributeName:
+			if buf.Len() > 0 {
+				buf.WriteString(".")
+			}
+			buf.WriteString(string(step))
+		case tftypes.ElementKeyString:
+			fmt.Fprintf(&buf, "[%q]", string(step))
+		case tftypes.ElementKeyInt:
+			fmt.Fprintf(&buf, "[%d]", int64(step))
+		default:
+			fmt.Fprintf(&buf, "[%s]", step)
+		}
+	}
+	return buf.String()
+}
+
+func errorDiagnostics(diagnostics []*tfprotov6.Diagnostic) []*tfprotov6.Diagnostic {
+	var problems []*tfprotov6.Diagnostic
+	for _, diagnostic := range diagnostics {
+		if diagnostic != nil && diagnostic.Severity == tfprotov6.DiagnosticSeverityError {
+			problems = append(problems, diagnostic)
+		}
+	}
+	return problems
+}
+
+func summaries(diagnostics []*tfprotov6.Diagnostic) []string {
+	messages := make([]string, 0, len(diagnostics))
+	for _, diagnostic := range diagnostics {
+		message := diagnostic.Summary
+		if detail := strings.TrimSpace(diagnostic.Detail); detail != "" {
+			message += ": " + detail
+		}
+		messages = append(messages, message)
+	}
+	return messages
+}
+
+// firstSummary returns the message for the diagnostic that named a path, so a
+// dropped attribute can be explained in the exporter's own words.
+func firstSummary(diagnostics []*tfprotov6.Diagnostic, path *tftypes.AttributePath) string {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Attribute != nil && diagnostic.Attribute.String() == path.String() {
+			return strings.Join(summaries([]*tfprotov6.Diagnostic{diagnostic}), "")
+		}
+	}
+	return "rejected by the provider"
+}

--- a/internal/exporter/discover.go
+++ b/internal/exporter/discover.go
@@ -1,0 +1,208 @@
+package exporter
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/ably/terraform-provider-ably/control"
+	"github.com/ably/terraform-provider-ably/internal/provider"
+)
+
+// Resource types with their own Control API collection endpoint: one
+// account-level list of apps and three app-level lists. Everything else in an
+// account is a rule, discovered via provider.RuleTypeResources.
+const (
+	resourceTypeApp       = "ably_app"
+	resourceTypeKey       = "ably_api_key"
+	resourceTypeNamespace = "ably_namespace"
+	resourceTypeQueue     = "ably_queue"
+)
+
+// SupportedResourceTypes returns every resource type the exporter can find.
+//
+// Rule types come from the provider's registry, so a new rule resource is
+// exported as soon as it appears there. Non-rule resources need a lister in
+// discover; TestSupportedResourceTypesCoverage checks for that.
+func SupportedResourceTypes() []string {
+	types := []string{
+		resourceTypeApp,
+		resourceTypeKey,
+		resourceTypeNamespace,
+		resourceTypeQueue,
+	}
+	for _, resourceType := range provider.RuleTypeResources {
+		types = append(types, resourceType)
+	}
+	sort.Strings(types)
+	return types
+}
+
+// Target is one resource found in an account, in the order it will be written.
+type Target struct {
+	// ResourceType is the Terraform resource type, e.g. "ably_rule_http".
+	ResourceType string
+	// ID is the resource's own Control API ID.
+	ID string
+	// AppID is the owning app, empty for account-level resources.
+	AppID string
+	// AppName is the owning app's name, used to build HCL labels.
+	AppName string
+	// Name is the resource's own name where it has one. Rules do not.
+	Name string
+	// RuleType is the Control API ruleType for rule resources, empty otherwise.
+	RuleType string
+}
+
+// discovery is the result of walking an account.
+type discovery struct {
+	Targets  []Target
+	Warnings []string
+}
+
+// discover walks an account and returns every resource the exporter can
+// export. appFilter, when non-empty, keeps only apps whose ID or name matches.
+func discover(ctx context.Context, client *control.Client, accountID string, appFilter []string) (*discovery, error) {
+	result := &discovery{}
+
+	apps, err := client.ListApps(ctx, accountID)
+	if err != nil {
+		return nil, fmt.Errorf("listing apps: %w", err)
+	}
+
+	apps, unmatched := filterApps(apps, appFilter)
+	if len(apps) == 0 {
+		if len(appFilter) > 0 {
+			return nil, fmt.Errorf("no apps in the account match %s", strings.Join(appFilter, ", "))
+		}
+		result.Warnings = append(result.Warnings, "the account has no apps")
+		return result, nil
+	}
+	// A filter that matched nothing is almost certainly a typo, and silently
+	// exporting the rest would look like it worked.
+	if len(unmatched) > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf(
+			"no app matched %s, so nothing was exported for it", strings.Join(unmatched, ", ")))
+	}
+
+	// Sort apps by name so output ordering doesn't depend on API ordering.
+	sort.Slice(apps, func(i, j int) bool {
+		if apps[i].Name != apps[j].Name {
+			return apps[i].Name < apps[j].Name
+		}
+		return apps[i].ID < apps[j].ID
+	})
+
+	for _, app := range apps {
+		result.Targets = append(result.Targets, Target{
+			ResourceType: resourceTypeApp,
+			ID:           app.ID,
+			AppName:      app.Name,
+			Name:         app.Name,
+		})
+
+		appTargets, warnings, err := discoverApp(ctx, client, app)
+		if err != nil {
+			return nil, err
+		}
+		result.Targets = append(result.Targets, appTargets...)
+		result.Warnings = append(result.Warnings, warnings...)
+	}
+
+	return result, nil
+}
+
+// discoverApp lists everything that lives inside a single app.
+func discoverApp(ctx context.Context, client *control.Client, app control.AppResponse) ([]Target, []string, error) {
+	var targets []Target
+	var warnings []string
+
+	target := func(resourceType, id, name, ruleType string) Target {
+		return Target{
+			ResourceType: resourceType,
+			ID:           id,
+			AppID:        app.ID,
+			AppName:      app.Name,
+			Name:         name,
+			RuleType:     ruleType,
+		}
+	}
+
+	keys, err := client.ListKeys(ctx, app.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing keys for app %s: %w", app.ID, err)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].ID < keys[j].ID })
+	for _, key := range keys {
+		// A non-zero status means revoked. The provider's Read treats those as
+		// gone, so exporting one gives config for a resource that isn't there.
+		if key.Status != 0 {
+			continue
+		}
+		targets = append(targets, target(resourceTypeKey, key.ID, key.Name, ""))
+	}
+
+	namespaces, err := client.ListNamespaces(ctx, app.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing namespaces for app %s: %w", app.ID, err)
+	}
+	sort.Slice(namespaces, func(i, j int) bool { return namespaces[i].ID < namespaces[j].ID })
+	for _, namespace := range namespaces {
+		targets = append(targets, target(resourceTypeNamespace, namespace.ID, namespace.ID, ""))
+	}
+
+	queues, err := client.ListQueues(ctx, app.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing queues for app %s: %w", app.ID, err)
+	}
+	sort.Slice(queues, func(i, j int) bool { return queues[i].ID < queues[j].ID })
+	for _, queue := range queues {
+		targets = append(targets, target(resourceTypeQueue, queue.ID, queue.Name, ""))
+	}
+
+	rules, err := client.ListRules(ctx, app.ID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("listing rules for app %s: %w", app.ID, err)
+	}
+	sort.Slice(rules, func(i, j int) bool { return rules[i].ID < rules[j].ID })
+	for _, rule := range rules {
+		resourceType, ok := provider.RuleTypeResources[rule.RuleType]
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf(
+				"skipped rule %s in app %s: the provider has no resource for ruleType %q",
+				rule.ID, app.ID, rule.RuleType))
+			continue
+		}
+		targets = append(targets, target(resourceType, rule.ID, "", rule.RuleType))
+	}
+
+	return targets, warnings, nil
+}
+
+// filterApps keeps the apps matching one of the filters by ID or name, or every
+// app when no filter is given. It also returns the filters that matched nothing.
+func filterApps(apps []control.AppResponse, appFilter []string) (kept []control.AppResponse, unmatched []string) {
+	if len(appFilter) == 0 {
+		return apps, nil
+	}
+
+	matched := make(map[string]bool, len(appFilter))
+	for _, app := range apps {
+		for _, filter := range appFilter {
+			wanted := strings.ToLower(strings.TrimSpace(filter))
+			if wanted == strings.ToLower(app.ID) || wanted == strings.ToLower(app.Name) {
+				matched[filter] = true
+				kept = append(kept, app)
+				break
+			}
+		}
+	}
+
+	for _, filter := range appFilter {
+		if !matched[filter] {
+			unmatched = append(unmatched, filter)
+		}
+	}
+	return kept, unmatched
+}

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -1,0 +1,501 @@
+// Package exporter generates Terraform configuration for the resources in an
+// Ably account, plus the import blocks to adopt them.
+//
+// It walks the account over the Control API, asks the provider to import and
+// read each resource it finds, and renders the resulting state as HCL.
+//
+// Schemas come from the provider over protocol v6 (see bridge.go), so new
+// attributes need no change here. A new rule type needs a line in the provider's
+// RuleTypeResources; a new resource family needs a lister in discover.go. Tests
+// fail if either is missed.
+package exporter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/ably/terraform-provider-ably/control"
+)
+
+// DefaultURL is the Control API the exporter talks to unless told otherwise,
+// matching the provider's own default.
+const DefaultURL = "https://control.ably.net/v1"
+
+// DefaultProviderVersion is the version constraint written into the generated
+// required_providers block.
+const DefaultProviderVersion = "~> 1.0"
+
+// Config is the input to an export run.
+type Config struct {
+	// Token is the Ably account token. Required.
+	Token string
+	// URL is the Control API base URL. Defaults to DefaultURL.
+	URL string
+	// Apps limits the export to apps matching these IDs or names. Empty
+	// exports every app in the account.
+	Apps []string
+	// Secrets decides what happens to sensitive values. Defaults to
+	// SecretsInline.
+	Secrets SecretMode
+	// Imports controls whether import blocks are generated.
+	Imports bool
+	// SingleFile writes everything to main.tf instead of one file per app.
+	SingleFile bool
+	// ProviderVersion is the version constraint for the generated
+	// required_providers block. Empty omits the constraint.
+	ProviderVersion string
+	// Version is the provider version the exporter reports to the Control API
+	// in its User-Agent.
+	Version string
+}
+
+// File is one generated file.
+type File struct {
+	Name    string
+	Content []byte
+}
+
+// Result is what an export produced.
+type Result struct {
+	// Files are the generated files, in the order they should be written.
+	Files []File
+	// Counts is the number of resources exported per resource type.
+	Counts map[string]int
+	// Total is the number of resources exported.
+	Total int
+	// Sensitive lists the sensitive attributes the export touched, as
+	// `resource.address.attribute.path`.
+	Sensitive []string
+	// Missing lists required attributes the Control API did not return, which
+	// have to be filled in before the config will apply.
+	Missing []string
+	// SecretsInline reports whether any secret was written into the output as a
+	// literal, which decides how the files are permissioned.
+	SecretsInline bool
+	// Variables reports whether a variables.tf was generated.
+	Variables bool
+	// Warnings describes anything skipped or worth a second look.
+	Warnings []string
+}
+
+// exported is a resource that has been read and rendered.
+type exported struct {
+	target   Target
+	label    string
+	importID string
+	hcl      string
+	// appLabel is the label of the app this resource belongs to, which decides
+	// the file it lands in.
+	appLabel string
+	// notes are written above the resource as comments, for anything the
+	// exporter could not resolve on its own.
+	notes []string
+}
+
+// Run exports an account. It performs read-only Control API calls.
+func Run(ctx context.Context, config Config) (*Result, error) {
+	if config.Token == "" {
+		return nil, errors.New("an Ably account token is required")
+	}
+	if config.URL == "" {
+		config.URL = DefaultURL
+	}
+	if config.Secrets == "" {
+		config.Secrets = SecretsInline
+	}
+	if config.Version == "" {
+		config.Version = "dev"
+	}
+
+	client := control.NewClient(config.Token)
+	client.BaseURL = config.URL
+	client.UserAgent += " terraform-provider-ably-exporter/" + config.Version
+
+	me, err := client.Me(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("looking up the account for this token: %w", err)
+	}
+	if me.Account == nil || me.Account.ID == "" {
+		return nil, errors.New("could not determine the account for this token; check it has account-level access")
+	}
+	accountID := me.Account.ID
+
+	bridge, err := newBridge(ctx, config.Version)
+	if err != nil {
+		return nil, err
+	}
+	if err := bridge.configure(ctx, config.Token, config.URL); err != nil {
+		return nil, err
+	}
+
+	found, err := discover(ctx, client, accountID, config.Apps)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Result{
+		Counts:   map[string]int{},
+		Warnings: found.Warnings,
+	}
+
+	labels, appLabels, references := assignLabels(found.Targets)
+	renderer := newRenderer(config.Secrets, references)
+
+	var exports []exported
+	for index, target := range found.Targets {
+		schema, err := bridge.schema(target.ResourceType)
+		if err != nil {
+			return nil, err
+		}
+
+		importID, err := bridge.importID(target.ResourceType, target.AppID, target.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		state, warnings, err := bridge.read(ctx, target.ResourceType, importID)
+		result.Warnings = append(result.Warnings, prefixWarnings(warnings, target, labels[index])...)
+		if err != nil {
+			if errors.Is(err, errResourceGone) {
+				result.Warnings = append(result.Warnings, fmt.Sprintf(
+					"skipped %s %q: it was deleted while the export was running", target.ResourceType, importID))
+				continue
+			}
+			return nil, err
+		}
+
+		// Render from the configuration the provider would accept rather than
+		// from raw state: computed values dropped, and anything the provider's
+		// validators reject taken back out.
+		resourceConfig, err := configValue(schema, state)
+		if err != nil {
+			return nil, fmt.Errorf("deriving config for %s %q: %w", target.ResourceType, importID, err)
+		}
+		resourceConfig, dropped, unresolved := repairConfig(ctx, bridge, target.ResourceType, labels[index], schema, resourceConfig)
+		result.Warnings = append(result.Warnings, dropped...)
+		result.Warnings = append(result.Warnings, unresolved...)
+
+		block, err := renderer.resourceBlock(target.ResourceType, labels[index], schema, resourceConfig)
+		if err != nil {
+			return nil, fmt.Errorf("rendering %s %q: %w", target.ResourceType, importID, err)
+		}
+
+		// An app owns the file its own resources go in.
+		appLabel := appLabels[target.AppID]
+		if target.ResourceType == resourceTypeApp {
+			appLabel = labels[index]
+		}
+
+		exports = append(exports, exported{
+			target:   target,
+			label:    labels[index],
+			importID: importID,
+			hcl:      block,
+			appLabel: appLabel,
+			notes:    unresolved,
+		})
+		result.Counts[target.ResourceType]++
+		result.Total++
+	}
+
+	result.Sensitive = renderer.sensitive
+	result.Missing = renderer.missing
+	result.SecretsInline = config.Secrets == SecretsInline && len(renderer.sensitive) > 0
+	result.Warnings = append(result.Warnings, renderer.skipped...)
+	result.Warnings = append(result.Warnings, renderer.missing...)
+
+	result.Files = buildFiles(config, exports, renderer.variables)
+	result.Variables = len(renderer.variables) > 0
+
+	return result, nil
+}
+
+// assignLabels gives every target an HCL label and records the reference
+// expression that points at it. Discovery emits an app before its children, so
+// one pass can name a child after its app.
+func assignLabels(targets []Target) (labels []string, appLabels map[string]string, references map[resourceRef]string) {
+	labeller := newLabeller()
+	labels = make([]string, len(targets))
+	references = map[resourceRef]string{}
+	appLabels = map[string]string{}
+
+	for index, target := range targets {
+		label := labeller.assign(target.ResourceType, labelFor(target, appLabels[target.AppID]))
+		labels[index] = label
+
+		if target.ResourceType == resourceTypeApp {
+			appLabels[target.ID] = label
+		}
+		// referenceableAttributes decides which attributes get rewritten.
+		references[resourceRef{target.ResourceType, target.ID}] = fmt.Sprintf("%s.%s.id", target.ResourceType, label)
+	}
+
+	return labels, appLabels, references
+}
+
+// buildFiles lays the rendered resources out into files.
+func buildFiles(config Config, exports []exported, variables []variableDecl) []File {
+	var files []File
+
+	files = append(files, formatFile("provider.tf", providerFile(config)))
+
+	grouped := map[string][]exported{}
+	var order []string
+	for _, export := range exports {
+		// One file per app, named for the app's label. The labeller has already
+		// made that unique, so two apps whose names sanitise alike keep separate
+		// files.
+		name := "main.tf"
+		if !config.SingleFile {
+			name = fmt.Sprintf("app_%s.tf", export.appLabel)
+		}
+		if _, seen := grouped[name]; !seen {
+			order = append(order, name)
+		}
+		grouped[name] = append(grouped[name], export)
+	}
+	sort.Strings(order)
+
+	for _, name := range order {
+		var buf strings.Builder
+		buf.WriteString(fileHeader())
+		for _, export := range grouped[name] {
+			buf.WriteString("\n")
+			for _, note := range export.notes {
+				fmt.Fprintf(&buf, "# TODO: %s\n", note)
+			}
+			buf.WriteString(export.hcl)
+		}
+		files = append(files, formatFile(name, buf.String()))
+	}
+
+	if len(variables) > 0 {
+		files = append(files, formatFile("variables.tf", variablesFile(variables)))
+	}
+
+	if config.Imports && len(exports) > 0 {
+		files = append(files, formatFile("imports.tf", importsFile(exports)))
+	}
+
+	return files
+}
+
+// generatedMarker opens every generated file, and is how WriteFiles recognises
+// its own output.
+const generatedMarker = "# Generated by the Ably Terraform exporter."
+
+// fileHeader tops every generated file. It names no account: the output is meant
+// to be committed.
+func fileHeader() string {
+	return generatedMarker + `
+# Review before applying: values the Control API does not return, write-only
+# secrets in particular, are absent and will be cleared on the first apply if
+# you do not fill them in.
+`
+}
+
+func providerFile(config Config) string {
+	var buf strings.Builder
+	buf.WriteString(fileHeader())
+	buf.WriteString("\nterraform {\n  required_providers {\n    ably = {\n      source = \"ably/ably\"\n")
+	if config.ProviderVersion != "" {
+		fmt.Fprintf(&buf, "      version = %s\n", quoteString(config.ProviderVersion))
+	}
+	buf.WriteString("    }\n  }\n}\n\nprovider \"ably\" {\n")
+	buf.WriteString("  # The account token is read from the ABLY_ACCOUNT_TOKEN environment variable.\n")
+	if config.URL != DefaultURL {
+		fmt.Fprintf(&buf, "  url = %s\n", quoteString(config.URL))
+	}
+	buf.WriteString("}\n")
+	return buf.String()
+}
+
+func variablesFile(variables []variableDecl) string {
+	var buf strings.Builder
+	buf.WriteString(fileHeader())
+	buf.WriteString("\n# Sensitive values are not written by the exporter. Supply them before applying.\n")
+
+	sorted := make([]variableDecl, len(variables))
+	copy(sorted, variables)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Name < sorted[j].Name })
+
+	seen := map[string]bool{}
+	for _, variable := range sorted {
+		if seen[variable.Name] {
+			continue
+		}
+		seen[variable.Name] = true
+		fmt.Fprintf(&buf, "\nvariable %s {\n", quoteString(variable.Name))
+		fmt.Fprintf(&buf, "  description = %s\n", quoteString(variable.Description))
+		fmt.Fprintf(&buf, "  type        = %s\n  sensitive   = true\n}\n", variable.Type)
+	}
+	return buf.String()
+}
+
+func importsFile(exports []exported) string {
+	var buf strings.Builder
+	buf.WriteString(fileHeader())
+	buf.WriteString(`
+# Import blocks adopt the resources above into Terraform state. Run
+# ` + "`terraform plan`" + ` first: it should report the imports and no other
+# changes. Delete this file once the imports have been applied.
+`)
+
+	for _, export := range exports {
+		fmt.Fprintf(&buf, "\nimport {\n  to = %s.%s\n  id = %s\n}\n",
+			export.target.ResourceType, export.label, quoteString(export.importID))
+	}
+	return buf.String()
+}
+
+// formatFile runs generated HCL through the same formatter `terraform fmt`
+// uses, so the output looks hand-written rather than machine-emitted.
+func formatFile(name, content string) File {
+	return File{Name: name, Content: hclwrite.Format([]byte(content))}
+}
+
+// prefixWarnings labels provider diagnostics with the resource they came from.
+func prefixWarnings(warnings []string, target Target, label string) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+	prefixed := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		prefixed = append(prefixed, fmt.Sprintf("%s.%s: %s", target.ResourceType, label, warning))
+	}
+	return prefixed
+}
+
+// WriteFiles writes an export to a directory, creating it if needed.
+//
+// Without force it refuses a directory that already holds Terraform files. With
+// force it first removes files a previous export wrote, because re-running with
+// different flags otherwise leaves a stale main.tf beside the app_*.tf that
+// replaced it, and duplicate resource blocks make Terraform reject the
+// directory. Files holding secrets are written 0600.
+func WriteFiles(directory string, result *Result, force bool) error {
+	if err := os.MkdirAll(directory, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", directory, err)
+	}
+
+	existing, err := filepath.Glob(filepath.Join(directory, "*.tf"))
+	if err != nil {
+		return err
+	}
+	if len(existing) > 0 && !force {
+		return fmt.Errorf("%s already contains Terraform files (%s); move them aside or pass -force",
+			directory, strings.Join(baseNames(existing), ", "))
+	}
+
+	if force {
+		if err := removeStaleExports(existing, result); err != nil {
+			return err
+		}
+	}
+
+	mode := os.FileMode(0o644)
+	if result.SecretsInline {
+		mode = 0o600
+	}
+
+	for _, file := range result.Files {
+		if err := writeFile(filepath.Join(directory, file.Name), file.Content, mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeFile writes content through a temporary file created with mode, then
+// renames it into place.
+//
+// Writing in place would put the content into whatever mode the existing file
+// already has, so re-exporting over a world-readable file would expose secrets
+// until the chmod landed. The rename also leaves the previous file intact if
+// anything fails part-way.
+func writeFile(path string, content []byte, mode os.FileMode) error {
+	temporary, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*")
+	if err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	name := temporary.Name()
+	// Unconditional cleanup: after a successful rename both calls fail
+	// harmlessly, and on an early return they tidy the temporary file away.
+	defer func() {
+		_ = temporary.Close()
+		_ = os.Remove(name)
+	}()
+
+	// CreateTemp makes the file 0600; widen it only if the content allows.
+	if err := temporary.Chmod(mode); err != nil {
+		return fmt.Errorf("setting permissions on %s: %w", path, err)
+	}
+	if _, err := temporary.Write(content); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	if err := os.Rename(name, path); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// removeStaleExports deletes Terraform files a previous export wrote that this
+// one won't replace. It only removes files carrying the exporter's own header, so
+// hand-written config survives -force.
+func removeStaleExports(existing []string, result *Result) error {
+	writing := make(map[string]bool, len(result.Files))
+	for _, file := range result.Files {
+		writing[file.Name] = true
+	}
+
+	for _, path := range existing {
+		if writing[filepath.Base(path)] {
+			continue
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		if !strings.HasPrefix(string(content), generatedMarker) {
+			continue
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing stale %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func baseNames(paths []string) []string {
+	names := make([]string, 0, len(paths))
+	for _, path := range paths {
+		names = append(names, filepath.Base(path))
+	}
+	return names
+}
+
+// Summary describes an export in the form the CLI prints.
+func (r *Result) Summary() string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "Exported %d resources:\n", r.Total)
+
+	types := make([]string, 0, len(r.Counts))
+	for resourceType := range r.Counts {
+		types = append(types, resourceType)
+	}
+	sort.Strings(types)
+	for _, resourceType := range types {
+		fmt.Fprintf(&buf, "  %-40s %d\n", resourceType, r.Counts[resourceType])
+	}
+	return buf.String()
+}

--- a/internal/exporter/exporter_test.go
+++ b/internal/exporter/exporter_test.go
@@ -1,0 +1,765 @@
+package exporter
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+
+	"github.com/ably/terraform-provider-ably/internal/provider"
+)
+
+// runExport exports the fake account and returns the generated files by name.
+func runExport(t *testing.T, config Config) (*Result, map[string]string) {
+	t.Helper()
+
+	fake := newFakeControlAPI(t)
+	config.Token = "fake-token"
+	config.URL = fake.url()
+
+	result, err := Run(context.Background(), config)
+	if err != nil {
+		t.Fatalf("Run: %s", err)
+	}
+
+	files := map[string]string{}
+	for _, file := range result.Files {
+		files[file.Name] = string(file.Content)
+	}
+	return result, files
+}
+
+func TestRunExportsEveryResourceInTheAccount(t *testing.T) {
+	result, files := runExport(t, Config{Imports: true, ProviderVersion: DefaultProviderVersion})
+
+	// One app, one active key, one namespace, one queue and three supported
+	// rules. The fourth rule has a ruleType the provider does not implement.
+	want := map[string]int{
+		"ably_app":            1,
+		"ably_api_key":        1,
+		"ably_namespace":      1,
+		"ably_queue":          1,
+		"ably_rule_http":      1,
+		"ably_rule_amqp":      1,
+		"ably_rule_bodyguard": 1,
+		"ably_rule_kafka":     1,
+	}
+	if result.Total != 8 {
+		t.Errorf("exported %d resources, want 8:\n%s", result.Total, result.Summary())
+	}
+	for resourceType, count := range want {
+		if result.Counts[resourceType] != count {
+			t.Errorf("exported %d of %s, want %d", result.Counts[resourceType], resourceType, count)
+		}
+	}
+
+	for name := range files {
+		t.Logf("generated %s", name)
+	}
+	config, ok := files["app_chat_service.tf"]
+	if !ok {
+		t.Fatalf("no per-app file was generated, got %v", fileNames(files))
+	}
+
+	// Labels come from names, so the app's resources are readable.
+	for _, want := range []string{
+		`resource "ably_app" "chat_service" {`,
+		`resource "ably_api_key" "chat_service_root_key" {`,
+		`resource "ably_namespace" "chat_service_chat" {`,
+		`resource "ably_queue" "chat_service_orders" {`,
+		`resource "ably_rule_http" "chat_service"`,
+	} {
+		if !strings.Contains(config, want) {
+			t.Errorf("generated config is missing %s:\n%s", want, config)
+		}
+	}
+}
+
+func TestRunWritesReferencesRatherThanIDs(t *testing.T) {
+	_, files := runExport(t, Config{})
+	config := files["app_chat_service.tf"]
+
+	assertAssigns(t, config, "app_id", "ably_app.chat_service.id")
+	if strings.Contains(config, `"app1"`) {
+		t.Errorf("an app ID was written as a literal:\n%s", config)
+	}
+	// The AMQP rule targets the exported queue, and the HTTP rule signs with the
+	// exported key, so both should point at them.
+	assertAssigns(t, config, "queue_id", "ably_queue.chat_service_orders.id")
+	assertAssigns(t, config, "signing_key_id", "ably_api_key.chat_service_root_key.id")
+	if strings.Contains(config, `"key1"`) {
+		t.Errorf("a key ID was written as a literal:\n%s", config)
+	}
+}
+
+// assertAssigns checks an assignment, tolerating the whitespace hclwrite inserts
+// to align equals signs.
+func assertAssigns(t *testing.T, config, attribute, value string) {
+	t.Helper()
+	pattern := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(attribute) + `\s*=\s*` + regexp.QuoteMeta(value) + `\s*$`)
+	if !pattern.MatchString(config) {
+		t.Errorf("expected %s = %s in:\n%s", attribute, value, config)
+	}
+}
+
+// TestRunOmitsComputedAttributes checks the invariant that makes the output
+// appliable: Terraform rejects config that sets a computed attribute. The list
+// comes from the provider's schemas rather than being written out here, so the
+// check survives schema changes.
+func TestRunOmitsComputedAttributes(t *testing.T) {
+	_, files := runExport(t, Config{})
+	config := files["app_chat_service.tf"]
+
+	bridge, err := newBridge(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("newBridge: %s", err)
+	}
+
+	// Attribute names are only meaningful within their own resource, so walk
+	// the file block by block.
+	resourceHeader := regexp.MustCompile(`^resource "([^"]+)" "([^"]+)" \{$`)
+	var computedHere map[string]bool
+	var currentType string
+
+	for _, line := range strings.Split(config, "\n") {
+		if match := resourceHeader.FindStringSubmatch(line); match != nil {
+			currentType = match[1]
+			schema, err := bridge.schema(currentType)
+			if err != nil {
+				t.Fatal(err)
+			}
+			computedHere = map[string]bool{}
+			for _, attribute := range computedOnlyAttributes(schema.Block) {
+				computedHere[attribute] = true
+			}
+			continue
+		}
+
+		// hclwrite aligns the equals signs, so the name carries trailing space.
+		name, _, isAssignment := strings.Cut(strings.TrimSpace(line), "=")
+		name = strings.TrimSpace(name)
+		if !isAssignment || currentType == "" {
+			continue
+		}
+		if computedHere[name] {
+			t.Errorf("generated config sets %s.%s, which the provider computes:\n%s", currentType, name, config)
+		}
+	}
+
+	// A configurable attribute of the same shape has to survive, otherwise the
+	// check above would pass on empty output.
+	if !strings.Contains(config, "app_id =") {
+		t.Errorf("app_id was dropped:\n%s", config)
+	}
+	// ably_namespace.id is required, not computed, so it must be written.
+	assertAssigns(t, config, "id", `"chat"`)
+}
+
+// computedOnlyAttributes returns attributes a user cannot set, at any depth.
+func computedOnlyAttributes(block *tfprotov6.SchemaBlock) []string {
+	if block == nil {
+		return nil
+	}
+	var names []string
+	var walk func(attributes []*tfprotov6.SchemaAttribute)
+	walk = func(attributes []*tfprotov6.SchemaAttribute) {
+		for _, attribute := range attributes {
+			if attribute == nil {
+				continue
+			}
+			if isComputedOnly(attribute) {
+				names = append(names, attribute.Name)
+			}
+			if attribute.NestedType != nil {
+				walk(attribute.NestedType.Attributes)
+			}
+		}
+	}
+	walk(block.Attributes)
+	return names
+}
+
+func TestRunRendersNestedAttributes(t *testing.T) {
+	_, files := runExport(t, Config{})
+	config := files["app_chat_service.tf"]
+
+	for _, want := range []string{"source = {", "target = {", "headers = [", "before_publish_config = {"} {
+		if !strings.Contains(config, want) {
+			t.Errorf("generated config is missing %q:\n%s", want, config)
+		}
+	}
+
+	assertAssigns(t, config, "url", `"https://example.com/hook?a=1"`)
+	assertAssigns(t, config, "name", `"X-Ably"`)
+	assertAssigns(t, config, "retry_timeout", "3000")
+	assertAssigns(t, config, `"chat:*"`, `["publish", "subscribe"]`)
+}
+
+func TestRunSkipsUnsupportedRuleTypesWithAWarning(t *testing.T) {
+	result, _ := runExport(t, Config{})
+
+	var found bool
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "hive/text-moderation") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a warning about the unsupported ruleType, got %v", result.Warnings)
+	}
+}
+
+func TestRunGeneratesImportBlocks(t *testing.T) {
+	_, files := runExport(t, Config{Imports: true})
+
+	imports, ok := files["imports.tf"]
+	if !ok {
+		t.Fatalf("no imports.tf was generated, got %v", fileNames(files))
+	}
+
+	// Account-level resources import by bare ID, app-scoped ones by
+	// "appID,id", which is the format the provider's ImportState expects.
+	assertAssigns(t, imports, "to", "ably_app.chat_service")
+	assertAssigns(t, imports, "id", `"app1"`)
+	assertAssigns(t, imports, "to", "ably_api_key.chat_service_root_key")
+	assertAssigns(t, imports, "id", `"app1,key1"`)
+	assertAssigns(t, imports, "to", "ably_rule_bodyguard.chat_service")
+	assertAssigns(t, imports, "id", `"app1,rule3"`)
+}
+
+func TestRunWithoutImports(t *testing.T) {
+	_, files := runExport(t, Config{Imports: false})
+	if _, ok := files["imports.tf"]; ok {
+		t.Error("imports.tf was generated despite Imports being false")
+	}
+}
+
+func TestRunSecretsInline(t *testing.T) {
+	result, files := runExport(t, Config{Secrets: SecretsInline})
+	config := files["app_chat_service.tf"]
+
+	assertAssigns(t, config, "api_key", `"bodyguard-secret"`)
+	if len(result.Sensitive) == 0 {
+		t.Error("inline mode did not report which attributes were sensitive")
+	}
+}
+
+func TestRunSecretsVars(t *testing.T) {
+	result, files := runExport(t, Config{Secrets: SecretsVars})
+	config := files["app_chat_service.tf"]
+
+	if strings.Contains(config, "bodyguard-secret") {
+		t.Errorf("vars mode leaked a sensitive value:\n%s", config)
+	}
+	assertAssigns(t, config, "api_key", "var.rule_bodyguard_chat_service_target_api_key")
+
+	variables, ok := files["variables.tf"]
+	if !ok {
+		t.Fatalf("vars mode generated no variables.tf, got %v", fileNames(files))
+	}
+	if !strings.Contains(variables, `variable "rule_bodyguard_chat_service_target_api_key" {`) {
+		t.Errorf("variables.tf is missing the declaration:\n%s", variables)
+	}
+	if !regexp.MustCompile(`sensitive\s*=\s*true`).MatchString(variables) {
+		t.Errorf("variables.tf does not mark the variable sensitive:\n%s", variables)
+	}
+	if len(result.Sensitive) == 0 {
+		t.Error("vars mode did not report which attributes were sensitive")
+	}
+}
+
+func TestRunSecretsOmit(t *testing.T) {
+	_, files := runExport(t, Config{Secrets: SecretsOmit})
+	config := files["app_chat_service.tf"]
+
+	if strings.Contains(config, "bodyguard-secret") {
+		t.Errorf("omit mode leaked a sensitive value:\n%s", config)
+	}
+	if !strings.Contains(config, "# api_key omitted: sensitive value") {
+		t.Errorf("omit mode did not leave a comment where the value was:\n%s", config)
+	}
+	if _, ok := files["variables.tf"]; ok {
+		t.Error("omit mode generated variables.tf")
+	}
+}
+
+func TestRunGeneratesParseableHCL(t *testing.T) {
+	for _, secrets := range []SecretMode{SecretsInline, SecretsVars, SecretsOmit} {
+		t.Run(string(secrets), func(t *testing.T) {
+			_, files := runExport(t, Config{Secrets: secrets, Imports: true, ProviderVersion: DefaultProviderVersion})
+
+			for name, content := range files {
+				parser := hclparse.NewParser()
+				_, diagnostics := parser.ParseHCL([]byte(content), name)
+				if diagnostics.HasErrors() {
+					t.Errorf("%s is not valid HCL: %s\n%s", name, diagnostics.Error(), content)
+				}
+			}
+		})
+	}
+}
+
+func TestRunSingleFile(t *testing.T) {
+	_, files := runExport(t, Config{SingleFile: true})
+
+	if _, ok := files["main.tf"]; !ok {
+		t.Fatalf("single-file mode did not generate main.tf, got %v", fileNames(files))
+	}
+	for name := range files {
+		if strings.HasPrefix(name, "app_") {
+			t.Errorf("single-file mode also generated %s", name)
+		}
+	}
+}
+
+func TestRunProviderFile(t *testing.T) {
+	_, files := runExport(t, Config{ProviderVersion: "~> 1.0"})
+
+	providerFile, ok := files["provider.tf"]
+	if !ok {
+		t.Fatalf("no provider.tf was generated, got %v", fileNames(files))
+	}
+	assertAssigns(t, providerFile, "source", `"ably/ably"`)
+	assertAssigns(t, providerFile, "version", `"~> 1.0"`)
+	for _, want := range []string{`provider "ably" {`, "ABLY_ACCOUNT_TOKEN"} {
+		if !strings.Contains(providerFile, want) {
+			t.Errorf("provider.tf is missing %q:\n%s", want, providerFile)
+		}
+	}
+	// A non-default Control API URL has to be carried into the config,
+	// otherwise the generated config would point at production.
+	if !strings.Contains(providerFile, "url =") {
+		t.Errorf("provider.tf does not pin the Control API URL it was exported from:\n%s", providerFile)
+	}
+}
+
+func TestRunFiltersByApp(t *testing.T) {
+	fake := newFakeControlAPI(t)
+
+	_, err := Run(context.Background(), Config{
+		Token: "fake-token",
+		URL:   fake.url(),
+		Apps:  []string{"no-such-app"},
+	})
+	if err == nil {
+		t.Fatal("filtering on an unknown app should fail rather than export nothing")
+	}
+	if !strings.Contains(err.Error(), "no-such-app") {
+		t.Errorf("error should name the filter that matched nothing, got %s", err)
+	}
+
+	// Filtering by name, case-insensitively, keeps the app.
+	result, err := Run(context.Background(), Config{
+		Token: "fake-token",
+		URL:   fake.url(),
+		Apps:  []string{"chat service"},
+	})
+	if err != nil {
+		t.Fatalf("Run with an app filter: %s", err)
+	}
+	if result.Counts["ably_app"] != 1 {
+		t.Errorf("app filter by name exported %d apps, want 1", result.Counts["ably_app"])
+	}
+}
+
+func TestRunRequiresAToken(t *testing.T) {
+	_, err := Run(context.Background(), Config{})
+	if err == nil {
+		t.Fatal("Run without a token should fail")
+	}
+}
+
+func TestRunOnlyReads(t *testing.T) {
+	fake := newFakeControlAPI(t)
+
+	if _, err := Run(context.Background(), Config{Token: "fake-token", URL: fake.url()}); err != nil {
+		t.Fatalf("Run: %s", err)
+	}
+
+	for _, request := range fake.recorded() {
+		if !strings.HasPrefix(request, "GET ") {
+			t.Errorf("the exporter made a non-read request: %s", request)
+		}
+	}
+}
+
+func TestWriteFilesRefusesToClobber(t *testing.T) {
+	result, _ := runExport(t, Config{})
+	directory := t.TempDir()
+
+	if err := WriteFiles(directory, result, false); err != nil {
+		t.Fatalf("WriteFiles into an empty directory: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "provider.tf")); err != nil {
+		t.Fatalf("provider.tf was not written: %s", err)
+	}
+
+	err := WriteFiles(directory, result, false)
+	if err == nil {
+		t.Fatal("WriteFiles overwrote an existing configuration without -force")
+	}
+	if !strings.Contains(err.Error(), "-force") {
+		t.Errorf("error should point at -force, got %s", err)
+	}
+
+	if err := WriteFiles(directory, result, true); err != nil {
+		t.Fatalf("WriteFiles with force: %s", err)
+	}
+}
+
+// TestSupportedResourceTypesCoverage keeps the exporter in step with the
+// provider. A resource it cannot find is a silent gap in an export, which is worse
+// than a failure here.
+func TestSupportedResourceTypesCoverage(t *testing.T) {
+	supported := map[string]bool{}
+	for _, resourceType := range SupportedResourceTypes() {
+		supported[resourceType] = true
+	}
+
+	for _, resourceType := range provider.ResourceTypeNames(context.Background()) {
+		if supported[resourceType] {
+			continue
+		}
+		if provider.IsRuleResourceType(resourceType) {
+			t.Errorf("the exporter cannot discover %s.\n"+
+				"Add its Control API ruleType to RuleTypeResources in internal/provider/rule_types.go.", resourceType)
+			continue
+		}
+		t.Errorf("the exporter cannot discover %s.\n"+
+			"Add a lister for it to discoverApp (or discover, if it is account-level) "+
+			"in internal/exporter/discover.go, and name it in SupportedResourceTypes.", resourceType)
+	}
+}
+
+func TestParseSecretMode(t *testing.T) {
+	for _, valid := range []string{"inline", "vars", "omit"} {
+		if _, err := ParseSecretMode(valid); err != nil {
+			t.Errorf("ParseSecretMode(%q): %s", valid, err)
+		}
+	}
+	if _, err := ParseSecretMode("plaintext"); err == nil {
+		t.Error("ParseSecretMode should reject unknown modes")
+	}
+}
+
+func fileNames(files map[string]string) []string {
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	return names
+}
+
+// TestRunRepairsConflictingAttributes covers what the protocol schema can't
+// describe: ably_namespace's identified attribute and its deprecated
+// authenticated alias conflict, a read returns both, and writing both is invalid.
+// The exporter learns this from the provider and drops the deprecated spelling.
+func TestRunRepairsConflictingAttributes(t *testing.T) {
+	result, files := runExport(t, Config{})
+	config := files["app_chat_service.tf"]
+
+	var repaired bool
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "dropped the deprecated ably_namespace.chat_service_chat.authenticated") {
+			repaired = true
+		}
+	}
+	if !repaired {
+		t.Errorf("expected the deprecated authenticated attribute to be dropped, warnings were %v", result.Warnings)
+	}
+
+	if strings.Contains(config, "authenticated") {
+		t.Errorf("the deprecated attribute survived into the config:\n%s", config)
+	}
+	assertAssigns(t, config, "identified", "false")
+}
+
+// TestRunGeneratesConfigTheProviderAccepts checks every resource was validated by
+// the provider, so nothing needs a human except values the API withholds.
+func TestRunGeneratesConfigTheProviderAccepts(t *testing.T) {
+	result, files := runExport(t, Config{Imports: true})
+
+	for _, warning := range result.Warnings {
+		for _, unresolved := range []string{"review it by hand", "gave up repairing", "could not validate"} {
+			if strings.Contains(warning, unresolved) {
+				t.Errorf("the provider rejected generated config: %s", warning)
+			}
+		}
+	}
+
+	// The only TODOs allowed are for required values the Control API does not
+	// return, and each one has to be reported in Missing so it reaches the user.
+	for name, content := range files {
+		for _, line := range strings.Split(content, "\n") {
+			if !strings.Contains(line, "# TODO:") {
+				continue
+			}
+			if !strings.Contains(line, "the Control API does not return it") {
+				t.Errorf("%s has an unexplained TODO: %s", name, strings.TrimSpace(line))
+			}
+		}
+	}
+	if len(result.Missing) == 0 {
+		t.Error("the Kafka rule's withheld credentials were not reported in Missing")
+	}
+}
+
+// TestRunFlagsWithheldRequiredValues covers the Kafka SASL credentials. The
+// Control API takes them on write and returns empty strings, so a literal export
+// would write password = "" and wipe the live credential on apply.
+func TestRunFlagsWithheldRequiredValues(t *testing.T) {
+	result, files := runExport(t, Config{})
+	config := files["app_chat_service.tf"]
+
+	if regexp.MustCompile(`(?m)^\s*(password|username)\s*=\s*""`).MatchString(config) {
+		t.Errorf("a withheld credential was written as an empty string:\n%s", config)
+	}
+	if !strings.Contains(config, "# TODO: password is required but the Control API does not return it") {
+		t.Errorf("the withheld password was not flagged:\n%s", config)
+	}
+
+	var reported bool
+	for _, missing := range result.Missing {
+		if strings.Contains(missing, "ably_rule_kafka.chat_service.target.auth.sasl.password") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("the withheld password was not reported, Missing was %v", result.Missing)
+	}
+}
+
+// TestRunWiresWithheldRequiredValuesToVariables checks vars mode turns a withheld
+// credential into a variable, the only mode that can yield config which applies
+// once the value is supplied.
+func TestRunWiresWithheldRequiredValuesToVariables(t *testing.T) {
+	_, files := runExport(t, Config{Secrets: SecretsVars})
+	config := files["app_chat_service.tf"]
+
+	assertAssigns(t, config, "password", "var.rule_kafka_chat_service_target_auth_sasl_password")
+
+	variables, ok := files["variables.tf"]
+	if !ok {
+		t.Fatalf("no variables.tf was generated, got %v", fileNames(files))
+	}
+	if !strings.Contains(variables, `variable "rule_kafka_chat_service_target_auth_sasl_password" {`) {
+		t.Errorf("no variable was declared for the withheld password:\n%s", variables)
+	}
+	if !strings.Contains(variables, "Required, but the Control API does not return it.") {
+		t.Errorf("the variable does not explain why it exists:\n%s", variables)
+	}
+}
+
+// TestRunFlagsConfigItCannotRepair covers the Control API returning a value the
+// provider won't accept. Writing it out quietly would fail at plan time for no
+// visible reason, so the exporter warns and leaves a TODO by the resource.
+func TestRunFlagsConfigItCannotRepair(t *testing.T) {
+	fake := newFakeControlAPIWith(t, func(rules map[string]map[string]any) {
+		config := rules["rule3"]["beforePublishConfig"].(map[string]any)
+		config["failedAction"] = "not-a-valid-action"
+	})
+
+	result, err := Run(context.Background(), Config{Token: "fake-token", URL: fake.url()})
+	if err != nil {
+		t.Fatalf("Run should still finish, got %s", err)
+	}
+
+	var reported bool
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "ably_rule_bodyguard.chat_service") && strings.Contains(warning, "review it by hand") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("expected a warning about the rejected config, warnings were %v", result.Warnings)
+	}
+
+	// The resource is still written, with the invalid value visible, so the
+	// user can see what the API returned and decide what to do.
+	var config string
+	for _, file := range result.Files {
+		if file.Name == "app_chat_service.tf" {
+			config = string(file.Content)
+		}
+	}
+	if !strings.Contains(config, "# TODO:") {
+		t.Errorf("no TODO was left next to the resource:\n%s", config)
+	}
+	assertAssigns(t, config, "failed_action", `"not-a-valid-action"`)
+}
+
+// TestRunDoesNotWriteTheAccountID checks nothing identifying the account reaches
+// the output, which is meant to be committed.
+func TestRunDoesNotWriteTheAccountID(t *testing.T) {
+	_, files := runExport(t, Config{Imports: true, Secrets: SecretsVars, ProviderVersion: DefaultProviderVersion})
+
+	for name, content := range files {
+		if strings.Contains(content, fakeAccountID) {
+			t.Errorf("%s names the account:\n%s", name, content)
+		}
+	}
+}
+
+// TestWriteFilesRemovesStaleExports covers re-running with different flags. A
+// main.tf left by -single-file beside the app_*.tf that replaced it declares the
+// same resources twice, and Terraform rejects the directory.
+func TestWriteFilesRemovesStaleExports(t *testing.T) {
+	directory := t.TempDir()
+
+	single, _ := runExport(t, Config{SingleFile: true})
+	if err := WriteFiles(directory, single, false); err != nil {
+		t.Fatalf("WriteFiles: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "main.tf")); err != nil {
+		t.Fatalf("main.tf was not written: %s", err)
+	}
+
+	perApp, _ := runExport(t, Config{})
+	if err := WriteFiles(directory, perApp, true); err != nil {
+		t.Fatalf("WriteFiles with force: %s", err)
+	}
+	if _, err := os.Stat(filepath.Join(directory, "main.tf")); !os.IsNotExist(err) {
+		t.Error("the stale main.tf survived, so two files now declare the same resources")
+	}
+	if _, err := os.Stat(filepath.Join(directory, "app_chat_service.tf")); err != nil {
+		t.Errorf("the new file was not written: %s", err)
+	}
+}
+
+// TestWriteFilesLeavesHandWrittenFilesAlone checks -force only clears the
+// exporter's own output.
+func TestWriteFilesLeavesHandWrittenFilesAlone(t *testing.T) {
+	directory := t.TempDir()
+	handWritten := filepath.Join(directory, "mine.tf")
+	if err := os.WriteFile(handWritten, []byte("# mine\nresource \"ably_app\" \"mine\" {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, _ := runExport(t, Config{})
+	if err := WriteFiles(directory, result, true); err != nil {
+		t.Fatalf("WriteFiles with force: %s", err)
+	}
+
+	if _, err := os.Stat(handWritten); err != nil {
+		t.Errorf("a hand-written file was deleted: %s", err)
+	}
+}
+
+// TestWriteFilesRestrictsPermissionsOnSecrets checks output holding credentials
+// isn't left world-readable.
+func TestWriteFilesRestrictsPermissionsOnSecrets(t *testing.T) {
+	for _, test := range []struct {
+		secrets SecretMode
+		want    os.FileMode
+	}{
+		{SecretsInline, 0o600},
+		{SecretsVars, 0o644},
+		{SecretsOmit, 0o644},
+	} {
+		t.Run(string(test.secrets), func(t *testing.T) {
+			directory := t.TempDir()
+			result, _ := runExport(t, Config{Secrets: test.secrets})
+			if err := WriteFiles(directory, result, false); err != nil {
+				t.Fatalf("WriteFiles: %s", err)
+			}
+
+			info, err := os.Stat(filepath.Join(directory, "app_chat_service.tf"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != test.want {
+				t.Errorf("%s mode wrote %#o, want %#o", test.secrets, got, test.want)
+			}
+		})
+	}
+}
+
+// TestRunWarnsAboutUnmatchedAppFilters covers a typo alongside a good filter.
+// Exporting only the app that matched, and saying nothing, looks like it worked.
+func TestRunWarnsAboutUnmatchedAppFilters(t *testing.T) {
+	fake := newFakeControlAPI(t)
+
+	result, err := Run(context.Background(), Config{
+		Token: "fake-token",
+		URL:   fake.url(),
+		Apps:  []string{"Chat Service", "typo-app"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %s", err)
+	}
+	if result.Counts["ably_app"] != 1 {
+		t.Errorf("exported %d apps, want the one that matched", result.Counts["ably_app"])
+	}
+
+	var warned bool
+	for _, warning := range result.Warnings {
+		if strings.Contains(warning, "typo-app") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("no warning named the filter that matched nothing, warnings were %v", result.Warnings)
+	}
+}
+
+// TestWriteFilesDoesNotWriteSecretsThroughAWorldReadableFile covers re-exporting
+// over output from a previous run: writing in place would put the secrets into
+// the existing 0644 file and only then tighten it.
+func TestWriteFilesDoesNotWriteSecretsThroughAWorldReadableFile(t *testing.T) {
+	directory := t.TempDir()
+
+	// Stand in for a previous export made without secrets.
+	loose, _ := runExport(t, Config{Secrets: SecretsOmit})
+	if err := WriteFiles(directory, loose, false); err != nil {
+		t.Fatalf("WriteFiles: %s", err)
+	}
+
+	withSecrets, _ := runExport(t, Config{Secrets: SecretsInline})
+	if err := WriteFiles(directory, withSecrets, true); err != nil {
+		t.Fatalf("WriteFiles with force: %s", err)
+	}
+
+	path := filepath.Join(directory, "app_chat_service.tf")
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("re-export left mode %#o, want 0600", got)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "bodyguard-secret") {
+		t.Error("the re-export did not replace the file contents")
+	}
+}
+
+// TestBuildFilesKeepsOneFilePerApp covers two apps whose names sanitise to the
+// same label. Filenames come from the label the labeller assigned, which is
+// already unique, so each app keeps its own file.
+func TestBuildFilesKeepsOneFilePerApp(t *testing.T) {
+	exports := []exported{
+		{target: Target{ResourceType: resourceTypeApp, ID: "app1", AppName: "Chat Service"}, label: "chat_service", appLabel: "chat_service"},
+		{target: Target{ResourceType: resourceTypeApp, ID: "app2", AppName: "chat-service"}, label: "chat_service_2", appLabel: "chat_service_2"},
+	}
+
+	var names []string
+	for _, file := range buildFiles(Config{}, exports, nil) {
+		names = append(names, file.Name)
+	}
+
+	for _, want := range []string{"app_chat_service.tf", "app_chat_service_2.tf"} {
+		if !slices.Contains(names, want) {
+			t.Errorf("expected %s among %v", want, names)
+		}
+	}
+}

--- a/internal/exporter/fake_control_api_test.go
+++ b/internal/exporter/fake_control_api_test.go
@@ -1,0 +1,258 @@
+package exporter
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// fakeControlAPI is a read-only, in-process stand-in for the Control API, serving
+// a fixed account so the exporter can be tested with no credentials and no
+// network. The exporter only reads, so a fixture is enough; the provider's own
+// fake is the stateful one used for CRUD.
+type fakeControlAPI struct {
+	server *httptest.Server
+
+	// mu guards requests, which is appended to on the server's goroutines and
+	// read from the test's.
+	mu sync.Mutex
+	// requests records the paths that were requested, so tests can assert the
+	// exporter is not making calls it should not.
+	requests []string
+}
+
+const fakeAccountID = "acc1"
+
+// newFakeControlAPI serves one account with one app holding a key, a namespace, a
+// queue and five rules. One rule has an unsupported ruleType; one is a Kafka rule
+// missing the SASL credentials the API never returns.
+func newFakeControlAPI(t *testing.T) *fakeControlAPI {
+	t.Helper()
+	return newFakeControlAPIWith(t, nil)
+}
+
+// newFakeControlAPIWith lets a test alter the rules first, for cases needing the
+// API to return something the provider won't accept.
+func newFakeControlAPIWith(t *testing.T, alter func(rules map[string]map[string]any)) *fakeControlAPI {
+	t.Helper()
+
+	fake := &fakeControlAPI{}
+
+	rules := map[string]map[string]any{
+		"rule1": {
+			"id":          "rule1",
+			"appId":       "app1",
+			"status":      "enabled",
+			"ruleType":    "http",
+			"requestMode": "single",
+			"source": map[string]any{
+				"channelFilter": "^chat:",
+				"type":          "channel.message",
+			},
+			"target": map[string]any{
+				"url":          "https://example.com/hook?a=1",
+				"headers":      []any{map[string]any{"name": "X-Ably", "value": "yes"}},
+				"signingKeyId": "key1",
+				"format":       "json",
+				"enveloped":    true,
+			},
+		},
+		"rule2": {
+			"id":          "rule2",
+			"appId":       "app1",
+			"status":      "enabled",
+			"ruleType":    "amqp",
+			"requestMode": "single",
+			"source": map[string]any{
+				"channelFilter": "",
+				"type":          "channel.message",
+			},
+			"target": map[string]any{
+				"queueId":   "queue1",
+				"enveloped": false,
+				"format":    "json",
+			},
+		},
+		"rule3": {
+			"id":             "rule3",
+			"appId":          "app1",
+			"status":         "enabled",
+			"ruleType":       "bodyguard/text-moderation",
+			"invocationMode": "BEFORE_PUBLISH",
+			"chatRoomFilter": "/room:.*/",
+			"beforePublishConfig": map[string]any{
+				"retryTimeout":          3000,
+				"maxRetries":            2,
+				"failedAction":          "PUBLISH",
+				"tooManyRequestsAction": "RETRY",
+			},
+			"target": map[string]any{
+				"apiKey":          "bodyguard-secret",
+				"channelId":       "chan-1",
+				"apiUrl":          "https://api.bodyguard.ai",
+				"defaultLanguage": "en",
+			},
+		},
+		"rule5": {
+			"id":          "rule5",
+			"appId":       "app1",
+			"status":      "enabled",
+			"ruleType":    "kafka",
+			"requestMode": "single",
+			"source": map[string]any{
+				"channelFilter": "",
+				"type":          "channel.message",
+			},
+			// The API returns the SASL block without the credentials it was given.
+			"target": map[string]any{
+				"routingKey": "key",
+				"brokers":    []any{"broker.example:9092"},
+				"auth":       map[string]any{"sasl": map[string]any{"mechanism": "scram-sha-256"}},
+				"enveloped":  false,
+				"format":     "json",
+			},
+		},
+		// A rule type the provider has no resource for. The exporter should skip
+		// it with a warning rather than failing the whole export.
+		"rule4": {
+			"id":       "rule4",
+			"appId":    "app1",
+			"status":   "enabled",
+			"ruleType": "hive/text-moderation",
+			"target":   map[string]any{"apiKey": "hive-secret"},
+		},
+	}
+
+	if alter != nil {
+		alter(rules)
+	}
+
+	responses := map[string]any{
+		"/me": map[string]any{
+			"account": map[string]any{"id": fakeAccountID, "name": "Test Account"},
+		},
+		"/accounts/" + fakeAccountID + "/apps": []any{
+			map[string]any{
+				"id":        "app1",
+				"accountId": fakeAccountID,
+				"name":      "Chat Service",
+				"status":    "enabled",
+				"tlsOnly":   true,
+				"created":   1600000000000,
+				"modified":  1600000000000,
+			},
+		},
+		"/apps/app1/keys": []any{
+			map[string]any{
+				"id":              "key1",
+				"appId":           "app1",
+				"name":            "root key",
+				"key":             "app1.key1:secret",
+				"status":          0,
+				"revocableTokens": false,
+				"capability":      map[string]any{"chat:*": []any{"publish", "subscribe"}},
+				"created":         1600000000000,
+				"modified":        1600000000000,
+			},
+			// Revoked keys are not exportable: the provider reads them as gone.
+			map[string]any{
+				"id":     "key2",
+				"appId":  "app1",
+				"name":   "revoked key",
+				"status": 1,
+			},
+		},
+		"/apps/app1/namespaces": []any{
+			map[string]any{
+				"id":          "chat",
+				"appId":       "app1",
+				"persisted":   true,
+				"persistLast": false,
+				"pushEnabled": false,
+				"tlsOnly":     false,
+			},
+		},
+		"/apps/app1/queues": []any{
+			map[string]any{
+				"id":         "queue1",
+				"appId":      "app1",
+				"name":       "orders",
+				"region":     "eu-west-1-a",
+				"ttl":        60,
+				"maxLength":  10000,
+				"state":      "active",
+				"deadletter": false,
+				"amqp":       map[string]any{"uri": "amqps://example", "queueName": "orders"},
+				"stomp":      map[string]any{"uri": "stomp://example", "host": "shared", "destination": "/orders"},
+			},
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fake.mu.Lock()
+		fake.requests = append(fake.requests, r.Method+" "+r.URL.Path)
+		fake.mu.Unlock()
+
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"message":"the exporter must only read"}`, http.StatusMethodNotAllowed)
+			return
+		}
+
+		if body, ok := responses[r.URL.Path]; ok {
+			writeJSON(t, w, body)
+			return
+		}
+
+		switch {
+		case r.URL.Path == "/apps/app1/rules":
+			list := make([]any, 0, len(rules))
+			for _, id := range slices.Sorted(maps.Keys(rules)) {
+				list = append(list, rules[id])
+			}
+			writeJSON(t, w, list)
+		case strings.HasPrefix(r.URL.Path, "/apps/app1/rules/"):
+			id := strings.TrimPrefix(r.URL.Path, "/apps/app1/rules/")
+			rule, ok := rules[id]
+			if !ok {
+				http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+				return
+			}
+			writeJSON(t, w, rule)
+		default:
+			http.Error(w, fmt.Sprintf(`{"message":"unexpected path %s"}`, r.URL.Path), http.StatusNotFound)
+		}
+	})
+
+	fake.server = httptest.NewServer(mux)
+	t.Cleanup(fake.server.Close)
+	return fake
+}
+
+// url is the base URL to give the exporter.
+func (f *fakeControlAPI) url() string {
+	return f.server.URL
+}
+
+// recorded returns a copy of the requests the fake has served.
+func (f *fakeControlAPI) recorded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.requests)
+}
+
+// writeJSON encodes a fixture. Errorf rather than Fatalf: FailNow from a handler
+// goroutine kills the response mid-flight and surfaces as a transport error.
+func writeJSON(t *testing.T, w http.ResponseWriter, body any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Errorf("encoding fake response: %s", err)
+	}
+}

--- a/internal/exporter/hcl.go
+++ b/internal/exporter/hcl.go
@@ -1,0 +1,649 @@
+package exporter
+
+import (
+	"fmt"
+	"math/big"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// SecretMode controls what the exporter writes for sensitive attributes.
+type SecretMode string
+
+const (
+	// SecretsInline writes sensitive values into the configuration as
+	// literals. The generated config is accurate and plans clean, but must be
+	// handled like any other file holding credentials.
+	SecretsInline SecretMode = "inline"
+	// SecretsVars replaces sensitive values with references to sensitive
+	// Terraform variables, declared in variables.tf. Safe to commit, but the
+	// values have to be supplied before the config will apply.
+	SecretsVars SecretMode = "vars"
+	// SecretsOmit leaves sensitive attributes out entirely, with a comment
+	// where each one would have gone.
+	SecretsOmit SecretMode = "omit"
+)
+
+// ParseSecretMode validates a -secrets flag value.
+func ParseSecretMode(value string) (SecretMode, error) {
+	switch SecretMode(value) {
+	case SecretsInline, SecretsVars, SecretsOmit:
+		return SecretMode(value), nil
+	default:
+		return "", fmt.Errorf("unknown secrets mode %q, expected inline, vars or omit", value)
+	}
+}
+
+// variableDecl is a sensitive Terraform variable the exporter declares in place
+// of a sensitive value, in SecretsVars mode.
+type variableDecl struct {
+	Name        string
+	Description string
+	Type        string
+}
+
+// renderer turns Terraform values into HCL, using the resource schema to decide
+// what belongs in a configuration: which attributes a user can set, which are
+// sensitive, and how values nest.
+type renderer struct {
+	secrets SecretMode
+	// references maps a resource type and Control API ID onto an HCL expression
+	// referring to the resource that owns it, so app_id becomes ably_app.foo.id.
+	references map[resourceRef]string
+
+	// Collected while rendering.
+	variables []variableDecl
+	sensitive []string
+	skipped   []string
+	// missing records required attributes the Control API withheld, which leave
+	// the config incomplete until someone fills them in.
+	missing []string
+}
+
+func newRenderer(secrets SecretMode, references map[resourceRef]string) *renderer {
+	return &renderer{secrets: secrets, references: references}
+}
+
+// resourceIdentity is how the renderer refers to what it is writing: an address
+// for messages, and a prefix unique to the resource for naming variables.
+type resourceIdentity struct {
+	address      string
+	variableBase string
+}
+
+func identityOf(resourceType, label string) resourceIdentity {
+	return resourceIdentity{
+		address:      resourceType + "." + label,
+		variableBase: strings.TrimPrefix(resourceType, "ably_") + "_" + label,
+	}
+}
+
+// resourceBlock renders a single resource block.
+func (r *renderer) resourceBlock(resourceType, label string, schema *tfprotov6.Schema, state tftypes.Value) (string, error) {
+	if schema == nil || schema.Block == nil {
+		return "", fmt.Errorf("resource type %s has no schema", resourceType)
+	}
+
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "resource %q %q {\n", resourceType, label)
+	if err := r.writeBlockBody(&buf, 1, schema.Block, state, identityOf(resourceType, label), nil); err != nil {
+		return "", err
+	}
+	buf.WriteString("}\n")
+	return buf.String(), nil
+}
+
+// writeBlockBody writes the attributes and nested blocks of one block body. path
+// is the attribute path walked so far, used for variable names and reported
+// notes.
+func (r *renderer) writeBlockBody(buf *strings.Builder, depth int, block *tfprotov6.SchemaBlock, value tftypes.Value, identity resourceIdentity, path []string) error {
+	if block == nil {
+		return nil
+	}
+	if err := r.writeAttributes(buf, depth, block.Attributes, value, identity, path); err != nil {
+		return err
+	}
+	return r.writeNestedBlocks(buf, depth, block.BlockTypes, value, identity, path)
+}
+
+// writeAttributes writes every attribute a user is allowed to set.
+func (r *renderer) writeAttributes(buf *strings.Builder, depth int, attributes []*tfprotov6.SchemaAttribute, value tftypes.Value, identity resourceIdentity, path []string) error {
+	if value.IsNull() || !value.IsKnown() {
+		return nil
+	}
+
+	values := map[string]tftypes.Value{}
+	if err := value.As(&values); err != nil {
+		return fmt.Errorf("decoding object at %s: %w", pathString(path), err)
+	}
+
+	for _, attribute := range sortAttributes(attributes) {
+		attributeValue, ok := values[attribute.Name]
+		if !ok {
+			continue
+		}
+		attributePath := childPath(path, attribute.Name)
+
+		// Computed-only attributes are the provider's to set, not the user's:
+		// writing them back would be rejected by Terraform.
+		if isComputedOnly(attribute) {
+			continue
+		}
+		// Write-only attributes are never persisted, so there is nothing to
+		// read back and nothing to export.
+		if attribute.WriteOnly {
+			continue
+		}
+		if !attributeValue.IsKnown() {
+			r.skipped = append(r.skipped, fmt.Sprintf("%s.%s (value unknown after read)", identity.address, pathString(attributePath)))
+			continue
+		}
+		// A required value the API withheld has to be flagged: left alone it
+		// either produces HCL Terraform refuses (null) or overwrites a live
+		// credential with an empty string on apply. Kafka SASL arrives this way.
+		if attribute.Required && withheld(attribute, attributeValue) {
+			r.writeMissingRequired(buf, depth, attribute, identity, attributePath)
+			continue
+		}
+		if attributeValue.IsNull() {
+			continue
+		}
+
+		if attribute.Sensitive {
+			written, err := r.writeSensitive(buf, depth, attribute, identity, attributePath)
+			if err != nil {
+				return err
+			}
+			if written {
+				continue
+			}
+		}
+
+		writeIndent(buf, depth)
+		fmt.Fprintf(buf, "%s = ", attribute.Name)
+		if err := r.writeValue(buf, depth, attribute, attributeValue, identity, attributePath); err != nil {
+			return err
+		}
+		buf.WriteString("\n")
+	}
+
+	return nil
+}
+
+// writeMissingRequired handles a required attribute the Control API withheld.
+//
+// Kafka SASL passwords, AWS secret keys and Pulsar TLS certs are accepted on
+// write and never read back. Nothing can recover them, so the gap is made
+// obvious rather than left to fail at plan time. In vars mode it wires up a
+// variable, so the config is complete once the value is supplied.
+func (r *renderer) writeMissingRequired(buf *strings.Builder, depth int, attribute *tfprotov6.SchemaAttribute, identity resourceIdentity, path []string) {
+	name := pathString(path)
+
+	if r.secrets == SecretsVars && isSimpleType(attribute) {
+		variable := r.declareVariable(attribute, identity, path,
+			fmt.Sprintf("%s of %s. Required, but the Control API does not return it.", name, identity.address))
+		writeIndent(buf, depth)
+		fmt.Fprintf(buf, "%s = var.%s\n", attribute.Name, variable)
+		r.missing = append(r.missing, fmt.Sprintf("%s.%s (required; supply it in variables.tf)", identity.address, name))
+		return
+	}
+
+	writeIndent(buf, depth)
+	fmt.Fprintf(buf, "# TODO: %s is required but the Control API does not return it. Fill it in before applying.\n", attribute.Name)
+	r.missing = append(r.missing, fmt.Sprintf("%s.%s (required; the Control API does not return it)", identity.address, name))
+}
+
+// withheld reports whether a value looks like one the Control API withheld.
+//
+// Null is the obvious case. An empty string counts only for sensitive
+// attributes: the provider maps absent credentials to "" rather than null (see
+// GetRuleResponse), and an empty credential is never intended. Elsewhere an empty
+// string can be legitimate.
+func withheld(attribute *tfprotov6.SchemaAttribute, value tftypes.Value) bool {
+	if value.IsNull() {
+		return true
+	}
+	if !attribute.Sensitive || !value.Type().Is(tftypes.String) {
+		return false
+	}
+	var literal string
+	if err := value.As(&literal); err != nil {
+		return false
+	}
+	return literal == ""
+}
+
+// declareVariable records a variable and returns its name. The name carries the
+// resource type and label as well as the path, because two resources of different
+// types can share a label and would otherwise share one variable.
+func (r *renderer) declareVariable(attribute *tfprotov6.SchemaAttribute, identity resourceIdentity, path []string, description string) string {
+	variable := sanitiseLabel(identity.variableBase + "_" + strings.Join(path, "_"))
+	r.variables = append(r.variables, variableDecl{
+		Name:        variable,
+		Description: description,
+		Type:        terraformType(attribute.Type),
+	})
+	return variable
+}
+
+// writeSensitive handles a sensitive attribute according to the secrets mode.
+// It returns true when it has dealt with the attribute itself, and false when
+// the value should be written inline as normal.
+func (r *renderer) writeSensitive(buf *strings.Builder, depth int, attribute *tfprotov6.SchemaAttribute, identity resourceIdentity, path []string) (bool, error) {
+	name := pathString(path)
+	r.sensitive = append(r.sensitive, fmt.Sprintf("%s.%s", identity.address, name))
+
+	switch r.secrets {
+	case SecretsOmit:
+		writeIndent(buf, depth)
+		fmt.Fprintf(buf, "# %s omitted: sensitive value. Re-run with -secrets=inline or -secrets=vars to export it.\n", attribute.Name)
+		return true, nil
+
+	case SecretsVars:
+		// A variable stands in for a single string, number or bool. An object or
+		// collection has no equivalent, so leave it out rather than emit config
+		// that cannot type-check.
+		if !isSimpleType(attribute) {
+			writeIndent(buf, depth)
+			fmt.Fprintf(buf, "# %s omitted: sensitive %s, which the exporter cannot replace with a variable. Re-run with -secrets=inline to export it.\n",
+				attribute.Name, attribute.Type)
+			return true, nil
+		}
+
+		variable := r.declareVariable(attribute, identity, path,
+			fmt.Sprintf("%s of %s. Sensitive, so the exporter did not write its value.", name, identity.address))
+		writeIndent(buf, depth)
+		fmt.Fprintf(buf, "%s = var.%s\n", attribute.Name, variable)
+		return true, nil
+
+	default:
+		return false, nil
+	}
+}
+
+// isSimpleType reports whether an attribute holds a single primitive value, the
+// only shape a variable can stand in for.
+func isSimpleType(attribute *tfprotov6.SchemaAttribute) bool {
+	if attribute.NestedType != nil || attribute.Type == nil {
+		return false
+	}
+	return attribute.Type.Is(tftypes.String) || attribute.Type.Is(tftypes.Number) || attribute.Type.Is(tftypes.Bool)
+}
+
+// terraformType names the Terraform type to declare a variable with.
+func terraformType(valueType tftypes.Type) string {
+	switch {
+	case valueType.Is(tftypes.Number):
+		return "number"
+	case valueType.Is(tftypes.Bool):
+		return "bool"
+	default:
+		return "string"
+	}
+}
+
+// writeValue writes a single value, recursing into nested objects.
+func (r *renderer) writeValue(buf *strings.Builder, depth int, attribute *tfprotov6.SchemaAttribute, value tftypes.Value, identity resourceIdentity, path []string) error {
+	if attribute.NestedType != nil {
+		return r.writeNestedValue(buf, depth, attribute.NestedType, value, identity, path)
+	}
+
+	// An ID that belongs to another exported resource is written as a
+	// reference so the config carries the dependency rather than a literal.
+	if len(path) > 0 && value.Type().Is(tftypes.String) {
+		if resourceType, referenceable := referenceableAttributes[path[len(path)-1]]; referenceable {
+			var literal string
+			if err := value.As(&literal); err == nil {
+				if expression, ok := r.references[resourceRef{resourceType, literal}]; ok {
+					buf.WriteString(expression)
+					return nil
+				}
+			}
+		}
+	}
+
+	return r.writePrimitive(buf, depth, value, path)
+}
+
+// writeNestedValue writes a nested attribute: a single object, or a
+// list/set/map of objects.
+func (r *renderer) writeNestedValue(buf *strings.Builder, depth int, nested *tfprotov6.SchemaObject, value tftypes.Value, identity resourceIdentity, path []string) error {
+	// elementKey distinguishes collection members, so a variable name or reported
+	// path points at one element.
+	writeObject := func(depth int, object tftypes.Value, elementKey string) error {
+		objectPath := path
+		if elementKey != "" {
+			objectPath = childPath(path, elementKey)
+		}
+		buf.WriteString("{\n")
+		if err := r.writeAttributes(buf, depth+1, nested.Attributes, object, identity, objectPath); err != nil {
+			return err
+		}
+		writeIndent(buf, depth)
+		buf.WriteString("}")
+		return nil
+	}
+
+	switch nested.Nesting {
+	case tfprotov6.SchemaObjectNestingModeSingle:
+		return writeObject(depth, value, "")
+
+	case tfprotov6.SchemaObjectNestingModeList, tfprotov6.SchemaObjectNestingModeSet:
+		elements := []tftypes.Value{}
+		if err := value.As(&elements); err != nil {
+			return fmt.Errorf("decoding %s: %w", pathString(path), err)
+		}
+		buf.WriteString("[\n")
+		for index, element := range elements {
+			writeIndent(buf, depth+1)
+			if err := writeObject(depth+1, element, strconv.Itoa(index)); err != nil {
+				return err
+			}
+			buf.WriteString(",\n")
+		}
+		writeIndent(buf, depth)
+		buf.WriteString("]")
+		return nil
+
+	case tfprotov6.SchemaObjectNestingModeMap:
+		elements := map[string]tftypes.Value{}
+		if err := value.As(&elements); err != nil {
+			return fmt.Errorf("decoding %s: %w", pathString(path), err)
+		}
+		buf.WriteString("{\n")
+		for _, key := range sortedKeys(elements) {
+			writeIndent(buf, depth+1)
+			fmt.Fprintf(buf, "%s = ", quoteString(key))
+			if err := writeObject(depth+1, elements[key], key); err != nil {
+				return err
+			}
+			buf.WriteString("\n")
+		}
+		writeIndent(buf, depth)
+		buf.WriteString("}")
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported nesting mode %d at %s", nested.Nesting, pathString(path))
+	}
+}
+
+// writePrimitive writes a value whose shape comes from its type: strings,
+// numbers, bools and collections of them.
+func (r *renderer) writePrimitive(buf *strings.Builder, depth int, value tftypes.Value, path []string) error {
+	valueType := value.Type()
+
+	switch {
+	case valueType.Is(tftypes.String):
+		var literal string
+		if err := value.As(&literal); err != nil {
+			return fmt.Errorf("decoding string at %s: %w", pathString(path), err)
+		}
+		buf.WriteString(quoteString(literal))
+		return nil
+
+	case valueType.Is(tftypes.Bool):
+		var literal bool
+		if err := value.As(&literal); err != nil {
+			return fmt.Errorf("decoding bool at %s: %w", pathString(path), err)
+		}
+		fmt.Fprintf(buf, "%t", literal)
+		return nil
+
+	case valueType.Is(tftypes.Number):
+		number := new(big.Float)
+		if err := value.As(&number); err != nil {
+			return fmt.Errorf("decoding number at %s: %w", pathString(path), err)
+		}
+		buf.WriteString(formatNumber(number))
+		return nil
+
+	case valueType.Is(tftypes.List{}), valueType.Is(tftypes.Set{}), valueType.Is(tftypes.Tuple{}):
+		elements := []tftypes.Value{}
+		if err := value.As(&elements); err != nil {
+			return fmt.Errorf("decoding collection at %s: %w", pathString(path), err)
+		}
+		return r.writeCollection(buf, depth, elements, path)
+
+	case valueType.Is(tftypes.Map{}), valueType.Is(tftypes.Object{}):
+		elements := map[string]tftypes.Value{}
+		if err := value.As(&elements); err != nil {
+			return fmt.Errorf("decoding map at %s: %w", pathString(path), err)
+		}
+		buf.WriteString("{\n")
+		for _, key := range sortedKeys(elements) {
+			writeIndent(buf, depth+1)
+			fmt.Fprintf(buf, "%s = ", quoteString(key))
+			if err := r.writePrimitive(buf, depth+1, elements[key], childPath(path, key)); err != nil {
+				return err
+			}
+			buf.WriteString("\n")
+		}
+		writeIndent(buf, depth)
+		buf.WriteString("}")
+		return nil
+
+	default:
+		return fmt.Errorf("cannot render type %s at %s", valueType, pathString(path))
+	}
+}
+
+// writeCollection writes a list, set or tuple. Short primitive collections stay
+// on one line.
+func (r *renderer) writeCollection(buf *strings.Builder, depth int, elements []tftypes.Value, path []string) error {
+	if len(elements) == 0 {
+		buf.WriteString("[]")
+		return nil
+	}
+
+	if collectionFitsOneLine(elements) {
+		buf.WriteString("[")
+		for i, element := range elements {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			if err := r.writePrimitive(buf, depth, element, path); err != nil {
+				return err
+			}
+		}
+		buf.WriteString("]")
+		return nil
+	}
+
+	buf.WriteString("[\n")
+	for _, element := range elements {
+		writeIndent(buf, depth+1)
+		if err := r.writePrimitive(buf, depth+1, element, path); err != nil {
+			return err
+		}
+		buf.WriteString(",\n")
+	}
+	writeIndent(buf, depth)
+	buf.WriteString("]")
+	return nil
+}
+
+// writeNestedBlocks renders nested blocks. The provider models everything as
+// attributes today; this is here so a resource added with real blocks still
+// exports.
+func (r *renderer) writeNestedBlocks(buf *strings.Builder, depth int, blocks []*tfprotov6.SchemaNestedBlock, value tftypes.Value, identity resourceIdentity, path []string) error {
+	if len(blocks) == 0 || value.IsNull() || !value.IsKnown() {
+		return nil
+	}
+
+	values := map[string]tftypes.Value{}
+	if err := value.As(&values); err != nil {
+		return fmt.Errorf("decoding object at %s: %w", pathString(path), err)
+	}
+
+	sorted := make([]*tfprotov6.SchemaNestedBlock, 0, len(blocks))
+	for _, block := range blocks {
+		if block != nil {
+			sorted = append(sorted, block)
+		}
+	}
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].TypeName < sorted[j].TypeName })
+
+	for _, block := range sorted {
+		blockValue, ok := values[block.TypeName]
+		if !ok || blockValue.IsNull() || !blockValue.IsKnown() {
+			continue
+		}
+		blockPath := childPath(path, block.TypeName)
+
+		writeBlock := func(body tftypes.Value, labels ...string) error {
+			writeIndent(buf, depth)
+			buf.WriteString(block.TypeName)
+			for _, blockLabel := range labels {
+				fmt.Fprintf(buf, " %s", quoteString(blockLabel))
+			}
+			buf.WriteString(" {\n")
+			if err := r.writeBlockBody(buf, depth+1, block.Block, body, identity, blockPath); err != nil {
+				return err
+			}
+			writeIndent(buf, depth)
+			buf.WriteString("}\n")
+			return nil
+		}
+
+		switch block.Nesting {
+		case tfprotov6.SchemaNestedBlockNestingModeSingle, tfprotov6.SchemaNestedBlockNestingModeGroup:
+			if err := writeBlock(blockValue); err != nil {
+				return err
+			}
+
+		case tfprotov6.SchemaNestedBlockNestingModeList, tfprotov6.SchemaNestedBlockNestingModeSet:
+			elements := []tftypes.Value{}
+			if err := blockValue.As(&elements); err != nil {
+				return fmt.Errorf("decoding %s: %w", pathString(blockPath), err)
+			}
+			for _, element := range elements {
+				if err := writeBlock(element); err != nil {
+					return err
+				}
+			}
+
+		case tfprotov6.SchemaNestedBlockNestingModeMap:
+			elements := map[string]tftypes.Value{}
+			if err := blockValue.As(&elements); err != nil {
+				return fmt.Errorf("decoding %s: %w", pathString(blockPath), err)
+			}
+			for _, key := range sortedKeys(elements) {
+				if err := writeBlock(elements[key], key); err != nil {
+					return err
+				}
+			}
+
+		default:
+			return fmt.Errorf("unsupported block nesting mode %d at %s", block.Nesting, pathString(blockPath))
+		}
+	}
+
+	return nil
+}
+
+// sortAttributes puts app_id first, which ties the resource to its app, then the
+// rest alphabetically.
+func sortAttributes(attributes []*tfprotov6.SchemaAttribute) []*tfprotov6.SchemaAttribute {
+	sorted := make([]*tfprotov6.SchemaAttribute, 0, len(attributes))
+	for _, attribute := range attributes {
+		if attribute != nil {
+			sorted = append(sorted, attribute)
+		}
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		if (sorted[i].Name == "app_id") != (sorted[j].Name == "app_id") {
+			return sorted[i].Name == "app_id"
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+	return sorted
+}
+
+// collectionFitsOneLine reports whether a collection is small enough to write
+// inline.
+func collectionFitsOneLine(elements []tftypes.Value) bool {
+	if len(elements) > 4 {
+		return false
+	}
+	width := 0
+	for _, element := range elements {
+		elementType := element.Type()
+		if !elementType.Is(tftypes.String) && !elementType.Is(tftypes.Number) && !elementType.Is(tftypes.Bool) {
+			return false
+		}
+		width += len(element.String())
+	}
+	return width <= 72
+}
+
+// formatNumber writes integers without a decimal point and everything else at
+// its shortest exact form.
+func formatNumber(number *big.Float) string {
+	if number.IsInt() {
+		integer, _ := number.Int(nil)
+		return integer.String()
+	}
+	return number.Text('f', -1)
+}
+
+// quoteString renders a string as an HCL quoted template. ${ and %{ are escaped
+// so values containing them aren't read as interpolations.
+func quoteString(value string) string {
+	var buf strings.Builder
+	buf.WriteByte('"')
+	for i := 0; i < len(value); i++ {
+		switch character := value[i]; character {
+		case '\\':
+			buf.WriteString(`\\`)
+		case '"':
+			buf.WriteString(`\"`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\r':
+			buf.WriteString(`\r`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '$', '%':
+			buf.WriteByte(character)
+			if i+1 < len(value) && value[i+1] == '{' {
+				buf.WriteByte(character)
+			}
+		default:
+			buf.WriteByte(character)
+		}
+	}
+	buf.WriteByte('"')
+	return buf.String()
+}
+
+func writeIndent(buf *strings.Builder, depth int) {
+	buf.WriteString(strings.Repeat("  ", depth))
+}
+
+// childPath extends an attribute path without sharing its backing array.
+func childPath(path []string, name string) []string {
+	child := make([]string, len(path), len(path)+1)
+	copy(child, path)
+	return append(child, name)
+}
+
+func pathString(path []string) string {
+	if len(path) == 0 {
+		return "(root)"
+	}
+	return strings.Join(path, ".")
+}
+
+func sortedKeys(values map[string]tftypes.Value) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/exporter/hcl_test.go
+++ b/internal/exporter/hcl_test.go
@@ -1,0 +1,312 @@
+package exporter
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2/hclparse"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestQuoteString(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"plain", `hello`, `"hello"`},
+		{"quotes", `say "hi"`, `"say \"hi\""`},
+		{"backslash", `a\b`, `"a\\b"`},
+		{"newline", "line\nline", `"line\nline"`},
+		{"tab", "a\tb", `"a\tb"`},
+		// An unescaped ${ would be read as an interpolation, and a Control API
+		// value that happens to contain one must survive the round trip.
+		{"interpolation", `${var.x}`, `"$${var.x}"`},
+		{"directive", `%{if true}`, `"%%{if true}"`},
+		{"lone dollar", `100$`, `"100$"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := quoteString(test.value); got != test.want {
+				t.Errorf("quoteString(%q) = %s, want %s", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+// TestQuoteStringProducesParseableHCL checks the escaping against a real HCL
+// parser, not just the expectations above.
+func TestQuoteStringProducesParseableHCL(t *testing.T) {
+	for _, value := range []string{
+		`plain`,
+		`with "quotes"`,
+		`with\backslash`,
+		"with\nnewline",
+		`${var.interpolation}`,
+		`%{if directive}`,
+		`regex ^chat:[a-z]+$`,
+	} {
+		source := "attribute = " + quoteString(value) + "\n"
+		parser := hclparse.NewParser()
+		file, diagnostics := parser.ParseHCL([]byte(source), "test.tf")
+		if diagnostics.HasErrors() {
+			t.Errorf("%q rendered unparseable HCL %s: %s", value, source, diagnostics.Error())
+			continue
+		}
+
+		attributes, diagnostics := file.Body.JustAttributes()
+		if diagnostics.HasErrors() {
+			t.Errorf("%q: %s", value, diagnostics.Error())
+			continue
+		}
+		got, diagnostics := attributes["attribute"].Expr.Value(nil)
+		if diagnostics.HasErrors() {
+			t.Errorf("%q did not evaluate: %s", value, diagnostics.Error())
+			continue
+		}
+		if got.AsString() != value {
+			t.Errorf("round trip changed %q into %q", value, got.AsString())
+		}
+	}
+}
+
+func TestFormatNumber(t *testing.T) {
+	for _, test := range []struct {
+		value *big.Float
+		want  string
+	}{
+		{big.NewFloat(0), "0"},
+		{big.NewFloat(60), "60"},
+		{big.NewFloat(10000), "10000"},
+		{big.NewFloat(1.5), "1.5"},
+		{big.NewFloat(-3), "-3"},
+	} {
+		if got := formatNumber(test.value); got != test.want {
+			t.Errorf("formatNumber(%s) = %s, want %s", test.value.String(), got, test.want)
+		}
+	}
+}
+
+func TestSanitiseLabel(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		want string
+	}{
+		{"Chat Service", "chat_service"},
+		{"my-app", "my_app"},
+		{"  spaced  ", "spaced"},
+		{"UPPER", "upper"},
+		{"lots???of___junk", "lots_of_junk"},
+		{"", "unnamed"},
+		{"!!!", "unnamed"},
+		// HCL identifiers cannot start with a digit.
+		{"2024 app", "r2024_app"},
+	} {
+		if got := sanitiseLabel(test.name); got != test.want {
+			t.Errorf("sanitiseLabel(%q) = %q, want %q", test.name, got, test.want)
+		}
+	}
+}
+
+func TestLabellerUniquePerResourceType(t *testing.T) {
+	labeller := newLabeller()
+
+	// Different types can share a label, so an app and its rules read alike.
+	if got := labeller.assign("ably_app", "Chat Service"); got != "chat_service" {
+		t.Errorf("first app label = %q, want chat_service", got)
+	}
+	if got := labeller.assign("ably_rule_http", "Chat Service"); got != "chat_service" {
+		t.Errorf("rule label = %q, want chat_service", got)
+	}
+
+	// The same type does not.
+	if got := labeller.assign("ably_rule_http", "Chat Service"); got != "chat_service_2" {
+		t.Errorf("second rule label = %q, want chat_service_2", got)
+	}
+	if got := labeller.assign("ably_rule_http", "Chat Service"); got != "chat_service_3" {
+		t.Errorf("third rule label = %q, want chat_service_3", got)
+	}
+}
+
+// TestRendererSkipsUnknownValues covers a provider leaving a value unknown after
+// a read: nothing to write, and it has to be reported rather than guessed.
+func TestRendererSkipsUnknownValues(t *testing.T) {
+	schema := &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{
+		Attributes: []*tfprotov6.SchemaAttribute{
+			{Name: "name", Type: tftypes.String, Required: true},
+			{Name: "region", Type: tftypes.String, Optional: true},
+		},
+	}}
+	stateType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"name":   tftypes.String,
+		"region": tftypes.String,
+	}}
+	state := tftypes.NewValue(stateType, map[string]tftypes.Value{
+		"name":   tftypes.NewValue(tftypes.String, "orders"),
+		"region": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+	})
+
+	renderer := newRenderer(SecretsInline, nil)
+	block, err := renderer.resourceBlock("ably_queue", "orders", schema, state)
+	if err != nil {
+		t.Fatalf("resourceBlock: %s", err)
+	}
+
+	if !strings.Contains(block, `name = "orders"`) {
+		t.Errorf("known value was not written:\n%s", block)
+	}
+	if strings.Contains(block, "region") {
+		t.Errorf("unknown value was written:\n%s", block)
+	}
+	if len(renderer.skipped) != 1 || !strings.Contains(renderer.skipped[0], "region") {
+		t.Errorf("the skipped attribute was not reported, got %v", renderer.skipped)
+	}
+}
+
+// TestRendererWritesNestedBlocks covers block-based schemas. The provider models
+// everything as attributes today, so nothing in an export hits this path yet.
+func TestRendererWritesNestedBlocks(t *testing.T) {
+	nestedType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"value": tftypes.String}}
+	schema := &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{
+		BlockTypes: []*tfprotov6.SchemaNestedBlock{{
+			TypeName: "setting",
+			Nesting:  tfprotov6.SchemaNestedBlockNestingModeList,
+			Block: &tfprotov6.SchemaBlock{
+				Attributes: []*tfprotov6.SchemaAttribute{{Name: "value", Type: tftypes.String, Required: true}},
+			},
+		}},
+	}}
+	stateType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+		"setting": tftypes.List{ElementType: nestedType},
+	}}
+	state := tftypes.NewValue(stateType, map[string]tftypes.Value{
+		"setting": tftypes.NewValue(tftypes.List{ElementType: nestedType}, []tftypes.Value{
+			tftypes.NewValue(nestedType, map[string]tftypes.Value{"value": tftypes.NewValue(tftypes.String, "one")}),
+			tftypes.NewValue(nestedType, map[string]tftypes.Value{"value": tftypes.NewValue(tftypes.String, "two")}),
+		}),
+	})
+
+	renderer := newRenderer(SecretsInline, nil)
+	block, err := renderer.resourceBlock("ably_example", "example", schema, state)
+	if err != nil {
+		t.Fatalf("resourceBlock: %s", err)
+	}
+
+	if strings.Count(block, "setting {") != 2 {
+		t.Errorf("expected two setting blocks:\n%s", block)
+	}
+	parser := hclparse.NewParser()
+	if _, diagnostics := parser.ParseHCL([]byte(block), "test.tf"); diagnostics.HasErrors() {
+		t.Errorf("block rendering is not valid HCL: %s\n%s", diagnostics.Error(), block)
+	}
+}
+
+// TestRendererVariableNamesAreUniquePerResource covers an easy collision: two
+// resources of different types can share a label, and a variable name built from
+// the label alone would serve both secrets.
+func TestRendererVariableNamesAreUniquePerResource(t *testing.T) {
+	schema := &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{
+		Attributes: []*tfprotov6.SchemaAttribute{
+			{Name: "url", Type: tftypes.String, Required: true, Sensitive: true},
+		},
+	}}
+	stateType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"url": tftypes.String}}
+	state := tftypes.NewValue(stateType, map[string]tftypes.Value{
+		"url": tftypes.NewValue(tftypes.String, "https://secret.example"),
+	})
+
+	renderer := newRenderer(SecretsVars, nil)
+	for _, resourceType := range []string{"ably_rule_http", "ably_rule_amqp_external"} {
+		if _, err := renderer.resourceBlock(resourceType, "chat_service", schema, state); err != nil {
+			t.Fatalf("resourceBlock(%s): %s", resourceType, err)
+		}
+	}
+
+	if len(renderer.variables) != 2 {
+		t.Fatalf("expected two variables, got %v", renderer.variables)
+	}
+	if renderer.variables[0].Name == renderer.variables[1].Name {
+		t.Errorf("two resources sharing a label got the same variable %q", renderer.variables[0].Name)
+	}
+}
+
+// TestRendererOmitsSensitiveCollectionsInVarsMode covers a sensitive attribute
+// that isn't a single value: var.x for a list would not type-check.
+func TestRendererOmitsSensitiveCollectionsInVarsMode(t *testing.T) {
+	listType := tftypes.List{ElementType: tftypes.String}
+	schema := &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{
+		Attributes: []*tfprotov6.SchemaAttribute{
+			{Name: "certs", Type: listType, Optional: true, Sensitive: true},
+		},
+	}}
+	stateType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"certs": listType}}
+	state := tftypes.NewValue(stateType, map[string]tftypes.Value{
+		"certs": tftypes.NewValue(listType, []tftypes.Value{tftypes.NewValue(tftypes.String, "secret-cert")}),
+	})
+
+	renderer := newRenderer(SecretsVars, nil)
+	block, err := renderer.resourceBlock("ably_rule_pulsar", "chat_service", schema, state)
+	if err != nil {
+		t.Fatalf("resourceBlock: %s", err)
+	}
+
+	if strings.Contains(block, "secret-cert") {
+		t.Errorf("vars mode leaked a sensitive collection:\n%s", block)
+	}
+	if strings.Contains(block, "var.") {
+		t.Errorf("vars mode pointed a collection at a string variable:\n%s", block)
+	}
+	if !strings.Contains(block, "# certs omitted") {
+		t.Errorf("no comment explains the omission:\n%s", block)
+	}
+	if len(renderer.variables) != 0 {
+		t.Errorf("expected no variable to be declared, got %v", renderer.variables)
+	}
+}
+
+func TestSanitiseLabelNonASCIIDigit(t *testing.T) {
+	// Unicode Nd is not ID_Start in HCL, so a leading Arabic-Indic digit needs
+	// the same prefix an ASCII one gets.
+	if got := sanitiseLabel("٣ chat"); !strings.HasPrefix(got, "r") {
+		t.Errorf("sanitiseLabel(\"٣ chat\") = %q, want a leading r", got)
+	}
+}
+
+// TestRendererVariableNamesIncludeCollectionKeys checks two sensitive values in
+// one collection get separate variables.
+func TestRendererVariableNamesIncludeCollectionKeys(t *testing.T) {
+	elementType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"value": tftypes.String}}
+	listType := tftypes.List{ElementType: elementType}
+	schema := &tfprotov6.Schema{Block: &tfprotov6.SchemaBlock{
+		Attributes: []*tfprotov6.SchemaAttribute{{
+			Name:     "headers",
+			Optional: true,
+			NestedType: &tfprotov6.SchemaObject{
+				Nesting:    tfprotov6.SchemaObjectNestingModeList,
+				Attributes: []*tfprotov6.SchemaAttribute{{Name: "value", Type: tftypes.String, Required: true, Sensitive: true}},
+			},
+		}},
+	}}
+	stateType := tftypes.Object{AttributeTypes: map[string]tftypes.Type{"headers": listType}}
+	element := func(value string) tftypes.Value {
+		return tftypes.NewValue(elementType, map[string]tftypes.Value{"value": tftypes.NewValue(tftypes.String, value)})
+	}
+	state := tftypes.NewValue(stateType, map[string]tftypes.Value{
+		"headers": tftypes.NewValue(listType, []tftypes.Value{element("first-secret"), element("second-secret")}),
+	})
+
+	renderer := newRenderer(SecretsVars, nil)
+	block, err := renderer.resourceBlock("ably_rule_http", "chat_service", schema, state)
+	if err != nil {
+		t.Fatalf("resourceBlock: %s", err)
+	}
+
+	if len(renderer.variables) != 2 {
+		t.Fatalf("expected two variables, got %v", renderer.variables)
+	}
+	if renderer.variables[0].Name == renderer.variables[1].Name {
+		t.Errorf("both list elements share the variable %q, so one secret is lost:\n%s",
+			renderer.variables[0].Name, block)
+	}
+}

--- a/internal/exporter/naming.go
+++ b/internal/exporter/naming.go
@@ -1,0 +1,111 @@
+package exporter
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// resourceRef identifies an exported resource by type and Control API ID.
+type resourceRef struct {
+	resourceType string
+	id           string
+}
+
+// referenceableAttributes maps an attribute holding another resource's ID onto
+// that resource's type. The exporter rewrites these as references, so the config
+// carries its dependencies: app_id = ably_app.foo.id rather than "abcdef".
+//
+// It is an allowlist, not a rule like "anything ending in _id", because plenty of
+// attributes hold unrelated identifiers (a Bodyguard channel_id, an Azure app ID)
+// that would be rewritten into nonsense on an ID collision. Pairing with the type
+// also stops a namespace ID being read as a queue ID.
+var referenceableAttributes = map[string]string{
+	"app_id":         resourceTypeApp,
+	"queue_id":       resourceTypeQueue,
+	"signing_key_id": resourceTypeKey,
+}
+
+// labeller hands out unique HCL resource labels, derived from Ably names rather
+// than IDs because the output is meant to be read. Same-type collisions get a
+// numeric suffix in discovery order, which is deterministic because discovery
+// sorts by ID.
+type labeller struct {
+	used map[string]bool
+}
+
+func newLabeller() *labeller {
+	return &labeller{used: map[string]bool{}}
+}
+
+// assign returns a label not yet used for resourceType. Labels only need to be
+// unique per type, so an app and its rules can share a name.
+func (l *labeller) assign(resourceType, base string) string {
+	label := sanitiseLabel(base)
+	if l.claim(resourceType, label) {
+		return label
+	}
+	for suffix := 2; ; suffix++ {
+		candidate := fmt.Sprintf("%s_%d", label, suffix)
+		if l.claim(resourceType, candidate) {
+			return candidate
+		}
+	}
+}
+
+func (l *labeller) claim(resourceType, label string) bool {
+	key := resourceType + "." + label
+	if l.used[key] {
+		return false
+	}
+	l.used[key] = true
+	return true
+}
+
+// sanitiseLabel turns an arbitrary Ably name into a valid HCL identifier.
+func sanitiseLabel(name string) string {
+	var builder strings.Builder
+	previousUnderscore := false
+
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case r >= 'a' && r <= 'z', unicode.IsDigit(r):
+			builder.WriteRune(r)
+			previousUnderscore = false
+		default:
+			if !previousUnderscore && builder.Len() > 0 {
+				builder.WriteRune('_')
+				previousUnderscore = true
+			}
+		}
+	}
+
+	label := strings.Trim(builder.String(), "_")
+	if label == "" {
+		return "unnamed"
+	}
+	// HCL identifiers can't start with a digit. Test the rune, not the first
+	// byte: the filter above accepts any Unicode digit.
+	if first, _ := utf8.DecodeRuneInString(label); unicode.IsDigit(first) {
+		label = "r" + label
+	}
+	return label
+}
+
+// labelFor builds the label base for a target. Named resources use their name;
+// rules have none, so they take their app's label and a numeric suffix when an
+// app has several of the same type.
+func labelFor(target Target, appLabel string) string {
+	switch {
+	case target.ResourceType == resourceTypeApp:
+		if target.Name != "" {
+			return target.Name
+		}
+		return target.ID
+	case target.Name != "":
+		return appLabel + "_" + sanitiseLabel(target.Name)
+	default:
+		return appLabel
+	}
+}

--- a/internal/provider/rule_types.go
+++ b/internal/provider/rule_types.go
@@ -1,0 +1,62 @@
+// Package provider implements the Ably provider for Terraform
+package provider
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// RuleTypeResources maps a Control API ruleType onto the Terraform resource type
+// that manages it.
+//
+// Every integration rule comes back from GET /apps/{id}/rules regardless of
+// family: webhooks, firehoses, ingress and moderation rules all arrive in one
+// list, told apart only by ruleType. Anything walking an account needs this
+// mapping to know which resource owns a rule, and it is otherwise implicit in the
+// type switches in rules.go and ingress_rules.go.
+//
+// Adding a rule resource means adding a line here. TestRuleTypeResources fails if
+// you forget, or if this table names a resource the provider doesn't register.
+var RuleTypeResources = map[string]string{
+	"aws/kinesis":                "ably_rule_kinesis",
+	"aws/sqs":                    "ably_rule_sqs",
+	"aws/lambda":                 "ably_rule_lambda",
+	"pulsar":                     "ably_rule_pulsar",
+	"kafka":                      "ably_rule_kafka",
+	"amqp":                       "ably_rule_amqp",
+	"amqp/external":              "ably_rule_amqp_external",
+	"http":                       "ably_rule_http",
+	"http/zapier":                "ably_rule_zapier",
+	"http/cloudflare-worker":     "ably_rule_cloudflare_worker",
+	"http/azure-function":        "ably_rule_azure_function",
+	"http/google-cloud-function": "ably_rule_google_function",
+	"http/ifttt":                 "ably_rule_ifttt",
+	"bodyguard/text-moderation":  "ably_rule_bodyguard",
+	"ingress/mongodb":            "ably_ingress_rule_mongodb",
+	"ingress-postgres-outbox":    "ably_ingress_rule_postgres_outbox",
+}
+
+// ResourceTypeNames returns the sorted type name of every resource the provider
+// registers. It asks each resource for its Metadata, so the list can't drift from
+// what the provider serves.
+func ResourceTypeNames(ctx context.Context) []string {
+	p := &AblyProvider{}
+	var names []string
+	for _, newResource := range p.Resources(ctx) {
+		var resp resource.MetadataResponse
+		newResource().Metadata(ctx, resource.MetadataRequest{ProviderTypeName: "ably"}, &resp)
+		names = append(names, resp.TypeName)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsRuleResourceType reports whether a resource type manages an integration rule,
+// and so needs an entry in RuleTypeResources. Those are named ably_rule_* or
+// ably_ingress_rule_*.
+func IsRuleResourceType(typeName string) bool {
+	return strings.Contains(typeName, "_rule_")
+}

--- a/internal/provider/rule_types_test.go
+++ b/internal/provider/rule_types_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+// TestRuleTypeResources keeps RuleTypeResources in step with the registered
+// resources, so a new rule resource can't be invisible to anything walking an
+// account by ruleType.
+func TestRuleTypeResources(t *testing.T) {
+	ctx := context.Background()
+
+	registered := map[string]bool{}
+	for _, name := range ResourceTypeNames(ctx) {
+		registered[name] = true
+	}
+
+	mapped := map[string]string{}
+	for ruleType, resourceType := range RuleTypeResources {
+		if !registered[resourceType] {
+			t.Errorf("RuleTypeResources maps ruleType %q to %q, which the provider does not register", ruleType, resourceType)
+		}
+		if other, dup := mapped[resourceType]; dup {
+			t.Errorf("resource %q is mapped from two ruleTypes, %q and %q", resourceType, other, ruleType)
+		}
+		mapped[resourceType] = ruleType
+	}
+
+	for name := range registered {
+		if !IsRuleResourceType(name) {
+			continue
+		}
+		if _, ok := mapped[name]; !ok {
+			t.Errorf("rule resource %q has no ruleType in RuleTypeResources.\n"+
+				"Add the Control API ruleType it manages to the table in rule_types.go, "+
+				"otherwise the exporter cannot tell which rules belong to it.", name)
+		}
+	}
+}


### PR DESCRIPTION
Adds `ably-exporter`, which turns an Ably account into Terraform config and the import blocks to adopt it. Point it at an account token and it walks the account read-only.

```sh
ABLY_ACCOUNT_TOKEN=... make export-account
cd ably-export && terraform init && terraform plan
```

`EXPORTER.md` covers the flags, the secrets modes, and what it can't recover.

Worth a look during review:

* Whether keeping the exporter out of the release `SHA256SUMS` is the call you'd make. It keeps the file identical to what the Registry verifies today, at the cost of the exporter shipping without checksums.
* Discovery is sequential. I didn't parallelise it because I don't know the Control API's rate limits well enough to guess, and a slow export beats a throttled one.
* `-url` exists but is hidden from `--help`, since customers have no reason to point this anywhere but production.

Verified against a fake Control API with the real provider binary and Terraform 1.15: `terraform fmt -check` clean, `terraform validate` passes, and `terraform plan` reports imports and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an account exporter that generates Terraform configuration and import blocks from existing accounts.
  * Supports app filtering, single- or multi-file output, configurable secret handling, and validation guidance.
  * Provider releases now include versioned exporter binaries and archives for supported platforms.

* **Documentation**
  * Added setup, usage, command-line options, secret-handling guidance, limitations, and Terraform workflow documentation.

* **Bug Fixes**
  * Improved generated configuration compatibility by handling deprecated or unsupported attributes safely.
  * Enhanced protection for exported files containing sensitive values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->