### PR TITLE
provider: normalise empty fcm_project_id on ably_app

### DIFF
--- a/internal/provider/fake_control_api_test.go
+++ b/internal/provider/fake_control_api_test.go
@@ -195,6 +195,9 @@ func (f *fakeControlAPI) createApp(w http.ResponseWriter, r *http.Request) {
 	body["id"] = id
 	body["accountId"] = fakeAccountID
 	body["created"] = ts
+	if _, ok := body["fcmProjectId"]; !ok {
+		body["fcmProjectId"] = ""
+	}
 	body["modified"] = ts
 	f.apps[id] = body
 	fakeWriteJSON(w, http.StatusCreated, body)
@@ -218,6 +221,9 @@ func (f *fakeControlAPI) updateApp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	maps.Copy(rec, body)
+	if _, ok := rec["fcmProjectId"]; !ok {
+		rec["fcmProjectId"] = ""
+	}
 	rec["modified"] = fakeNow()
 	fakeWriteJSON(w, http.StatusOK, rec)
 }

--- a/internal/provider/resource_ably_app.go
+++ b/internal/provider/resource_ably_app.go
@@ -286,6 +286,7 @@ func (r ResourceApp) Create(ctx context.Context, req resource.CreateRequest, res
 	emptyStringToNull(&respApps.ApnsCertificate)
 	emptyStringToNull(&respApps.ApnsPrivateKey)
 	emptyStringToNull(&respApps.ApnsSigningKey)
+	emptyStringToNull(&respApps.FcmProjectId)
 
 	// Sets state for the new Ably App.
 	diags = resp.State.Set(ctx, respApps)
@@ -355,6 +356,7 @@ func (r ResourceApp) Read(ctx context.Context, req resource.ReadRequest, resp *r
 			emptyStringToNull(&respApps.ApnsCertificate)
 			emptyStringToNull(&respApps.ApnsPrivateKey)
 			emptyStringToNull(&respApps.ApnsSigningKey)
+			emptyStringToNull(&respApps.FcmProjectId)
 			found = true
 
 			// Sets state to app values.
@@ -480,6 +482,7 @@ func (r ResourceApp) Update(ctx context.Context, req resource.UpdateRequest, res
 	emptyStringToNull(&respApps.ApnsCertificate)
 	emptyStringToNull(&respApps.ApnsPrivateKey)
 	emptyStringToNull(&respApps.ApnsSigningKey)
+	emptyStringToNull(&respApps.FcmProjectId)
 
 	// Sets state to new app.
 	diags = resp.State.Set(ctx, respApps)

--- a/internal/provider/resource_ably_app_test.go
+++ b/internal/provider/resource_ably_app_test.go
@@ -230,3 +230,45 @@ resource "ably_app" "app0" {
 		},
 	})
 }
+
+// The Control API returns fcmProjectId as an empty string for apps whose FCM
+// project was never set (any app created or patched by the pre-1.0 client is in
+// this state). An app that does not configure fcm_project_id must therefore
+// apply cleanly and produce an empty follow-up plan.
+func TestAccAblyAppEmptyFCMProjectID(t *testing.T) {
+	appName := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	config := fmt.Sprintf(`
+terraform {
+	required_providers {
+		ably = {
+			source = "registry.terraform.io/ably/ably"
+		}
+	}
+}
+provider "ably" {}
+
+resource "ably_app" "app0" {
+	name     = %[1]q
+	status   = "enabled"
+	tls_only = true
+}
+`, appName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ably_app.app0", "name", appName),
+					resource.TestCheckNoResourceAttr("ably_app.app0", "fcm_project_id"),
+				),
+			},
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes #252.

### Problem

On `v1.0.0`, an `ably_app` that does not set `fcm_project_id` plans a perpetual in-place update and fails to apply:

```text
Error: Provider produced inconsistent result after apply
value: .fcm_project_id: was null, but now cty.StringVal("").
```

The Control API returns `"fcmProjectId": ""` for apps whose FCM project was never set. That is every app created or patched by the pre-1.0 provider, since `ably-control-go` serialised the field without `omitempty`. `fcm_project_id` is `Optional` but not `Computed`, so the framework plans `null` from the config while Read and Update store `""`.

### Change

- `resource_ably_app.go`: normalise an empty `fcm_project_id` to null in Create, Read and Update, exactly as `fcm_key`, `apns_certificate`, `apns_private_key` and `apns_signing_key` already are.
- `fake_control_api_test.go`: the hermetic fake now returns `fcmProjectId: ""` when unset, mirroring the real API.
- `resource_ably_app_test.go`: regression test creating an `ably_app` without push configuration and checking the follow-up plan is empty.

### Verification

- The new test fails on unpatched `main` with the exact error above and passes with the fix.
- The full hermetic `internal/provider` suite passes.
- Verified against a real account: `ReadResource` returned `fcm_project_id = ""` while `PlanResourceChange.ProposedNewState` carried `null`, for every app previously written by provider 0.x.

### Alternative considered

The generated schema under `codegen/resource_app` declares `fcm_project_id` as `Optional` + `Computed`, which would also avoid the mismatch. The normalisation is the smaller change and keeps the current semantics for users who unset the field, but happy to switch if you prefer aligning the hand-written schema with the generated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of apps created without an FCM project ID.
  - Empty FCM project ID values are now treated as unset, preventing unnecessary configuration differences after creation, updates, or refreshes.
  - Added validation to ensure apps without an FCM project ID produce a clean follow-up plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->